### PR TITLE
Added support for loading FIRM directly from emunand

### DIFF
--- a/source/crypto.h
+++ b/source/crypto.h
@@ -53,7 +53,26 @@
 #define AES_KEYX		1
 #define AES_KEYY		2
 
+#define REG_SHACNT      ((volatile uint32_t*)0x1000A000)
+#define REG_SHABLKCNT   ((volatile uint32_t*)0x1000A004)
+#define REG_SHAHASH     ((volatile uint32_t*)0x1000A040)
+#define REG_SHAINFIFO   ((volatile uint32_t*)0x1000A080)
+
+#define SHA_CNT_STATE           0x00000003
+#define SHA_CNT_OUTPUT_ENDIAN   0x00000008
+#define SHA_CNT_MODE            0x00000030
+#define SHA_CNT_ENABLE          0x00010000
+#define SHA_CNT_ACTIVE          0x00020000
+
+#define SHA_HASH_READY          0x00000000
+#define SHA_NORMAL_ROUND        0x00000001
+#define SHA_FINAL_ROUND         0x00000002
+
+#define SHA256_MODE             0
+#define SHA224_MODE             0x00000010
+#define SHA1_MODE               0x00000020
+
 //NAND/FIRM stuff
-void nandFirm0(u8 *outbuf, u32 size, u32 console);
+void nandFirm0(u32 usesd, u32 sdoff, u8 *outbuf, u32 size, u32 console);
 void decryptArm9Bin(u8 *arm9Section, u32 mode);
 void setKeyXs(u8 *arm9Section);

--- a/source/fatfs/sdmmc/sdmmc.h
+++ b/source/fatfs/sdmmc/sdmmc.h
@@ -125,3 +125,4 @@ mmcdevice *getMMCDevice(int drive);
 
 u32 sdmmc_nand_readsectors(u32 sector_no, u32 numsectors, vu8 *out);
 u32 sdmmc_nand_writesectors(u32 sector_no, u32 numsectors, vu8 *in);
+int sdmmc_get_cid(int isNand, uint32_t *info);

--- a/source/firm.c
+++ b/source/firm.c
@@ -162,10 +162,19 @@ void loadFirm(void){
     if(!usePatchedFirm && !a9lhSetup && !mode){
         //Read FIRM from NAND and write to FCRAM
         firmSize = console ? 0xF2000 : 0xE9000;
-        nandFirm0((u8 *)firm, firmSize, console);
+        nandFirm0(0, 0, (u8 *)firm, firmSize, console);
         //Check for correct decryption
         if(memcmp(firm, "FIRM", 4) != 0)
             error("Couldn't decrypt NAND FIRM0 (O3DS not on 9.x?)");
+    }
+    // Load firm from emuNAND
+    else if (!usePatchedFirm && emuNAND){
+        //Read FIRM from NAND and write to FCRAM
+        firmSize = console ? 0xF2000 : 0xE9000;
+        nandFirm0(1, emuOffset, (u8 *)firm, firmSize, console);
+        //Check for correct decryption
+        if(memcmp(firm, "FIRM", 4) != 0)
+            error("Couldn't decrypt emuNAND FIRM0");
     }
     //Load FIRM from SD
     else{


### PR DESCRIPTION
Added SHA support to crypto.c
Decrypt FIRM using SHA of CID directly (required for A9LH since the data is not already in memory)

(Note this makes emuNAND FIRM the default and is used even if firmware.bin exists; you may or may not want to change the loading priority)
