### PR TITLE
Support for injector of any size (within reason)

### DIFF
--- a/source/firm.c
+++ b/source/firm.c
@@ -281,16 +281,15 @@ void patchFirm(void){
     //Replace the FIRM loader with the injector
     u32 loaderOffset,
         loaderSize;
+    u8 *sec0;
+    char temp[100];
 
-    getLoader((u8 *)firm + section[0].offset, section[0].size, &loaderOffset, &loaderSize);
-    //Check that the injector CXI isn't larger than the original
-    if(injector_size <= (int)loaderSize){
-        memset((void *)loaderOffset, 0, loaderSize);
-        memcpy((void *)loaderOffset, injector, injector_size);
-        //Patch content size and ExeFS size to match the repaced loader's ones
-        *((u32 *)loaderOffset + 0x41) = loaderSize / 0x200;
-        *((u32 *)loaderOffset + 0x69) = loaderSize / 0x200 - 5;
-    }
+    sec0 = (u8 *)firm + section[0].offset;
+    getLoader(sec0, section[0].size, &loaderOffset, &loaderSize);
+    memmove(sec0 + loaderOffset + injector_size, 
+            sec0 + loaderOffset + loaderSize, 
+            section[0].size - (loaderOffset + loaderSize));
+    memcpy(sec0 + loaderOffset, injector, injector_size);
 
     //Patch ARM9 entrypoint on N3DS to skip arm9loader
     if(console)

--- a/source/memory.c
+++ b/source/memory.c
@@ -15,6 +15,17 @@ void memcpy(void *dest, const void *src, u32 size){
         destc[i] = srcc[i];
 }
 
+void memmove(void *dest, const void *src, u32 size){
+    if (dest < src)
+        return memcpy(dest, src, size);
+    else{
+        u8 *destc = (u8 *)dest;
+        const u8 *srcc = (const u8 *)src;
+        for(u32 i = size-1; i >= 0; i--)
+            destc[i] = srcc[i];
+    }
+}
+
 void memset(void *dest, int filler, u32 size){
     u8 *destc = (u8 *)dest;
     for(u32 i = 0; i < size; i++)

--- a/source/memory.h
+++ b/source/memory.h
@@ -11,6 +11,7 @@
 #include "types.h"
 
 void memcpy(void *dest, const void *src, u32 size);
+void memmove(void *dest, const void *src, u32 size);
 void memset(void *dest, int filler, u32 size);
 void memset32(void *dest, u32 filler, u32 size);
 int memcmp(const void *buf1, const void *buf2, u32 size);

--- a/source/patches.c
+++ b/source/patches.c
@@ -64,6 +64,6 @@ u16 *getFirmWrite(u8 *pos, u32 size){
 void getLoader(u8 *pos, u32 size, u32 *loaderOffset, u32 *loaderSize){
     u8 *const off = memsearch(pos, "loade", size, 5);
 
-    *loaderOffset = (u32)off - 0x200;
+    *loaderOffset = (u32)(off - pos) - 0x200;
     *loaderSize = *(u32 *)(off - 0xFC) * 0x200;
 }


### PR DESCRIPTION
The original implementation is broken (you can't just change the NCCH header and zero out the rest of the memory), the bootstrap loader will try to load the 00 region as a CXI.

This moves the memory after "loader" to make room for injector (smaller or bigger). 
