### PR TITLE
Added a "Child Mode"

### DIFF
--- a/source/config.c
+++ b/source/config.c
@@ -29,7 +29,8 @@ void configureCFW(const char *configPath)
                                         "( ) Use developer UNITINFO",
                                         "( ) Show current NAND in System Settings",
                                         "( ) Show GBA boot screen in patched AGB_FIRM",
-                                        "( ) Enable splash screen with no screen-init" };
+                                        "( ) Enable splash screen with no screen-init",
+                                        "( ) Disable payloads and config menu"};
 
     struct multiOption {
         int posXs[4];

--- a/source/firm.c
+++ b/source/firm.c
@@ -133,12 +133,13 @@ void main(void)
             /* If L and R/Select or one of the single payload buttons are pressed and, if not using A9LH,
                the Safe Mode combo is not pressed, chainload an external payload */
             if(((pressed & SINGLE_PAYLOAD_BUTTONS) || ((pressed & BUTTON_L1) && (pressed & L_PAYLOAD_BUTTONS)))
-               && pressed != SAFE_MODE)
+               && pressed != SAFE_MODE && !(CONFIG(9)))
                 loadPayload();
 
             //If no configuration file exists or SELECT is held, load configuration menu
             if(needConfig == 2 || (pressed & BUTTON_SELECT))
-                configureCFW(configPath);
+                if(!(CONFIG(9)))
+                    configureCFW(configPath);
 
             //If screens are inited or the corresponding option is set, load splash screen
             if(PDN_GPU_CNT != 1 || CONFIG(8)) loadSplash();


### PR DESCRIPTION
Enabling this disables all external payloads + the config menu. The only way to remove this option is to delete config.bin.
