### PR TITLE
Added posibility to suffix payload file names with "_ANYTHING" to make it easier to keep track of payloads.

### DIFF
--- a/loader/source/fatfs/ffconf.h
+++ b/loader/source/fatfs/ffconf.h
@@ -15,7 +15,7 @@
 /  and optional writing functions as well. */
 
 
-#define _FS_MINIMIZE	3
+#define _FS_MINIMIZE	1
 /* This option defines minimization level to remove some basic API functions.
 /
 /   0: All basic functions are enabled.
@@ -34,7 +34,7 @@
 /  2: Enable with LF-CRLF conversion. */
 
 
-#define _USE_FIND		0
+#define _USE_FIND		1
 /* This option switches filtered directory read feature and related functions,
 /  f_findfirst() and f_findnext(). (0:Disable or 1:Enable) */
 

--- a/loader/source/main.c
+++ b/loader/source/main.c
@@ -1,13 +1,18 @@
 #include "types.h"
 #include "buttons.h"
 #include "fatfs/ff.h"
+#include "string.h"
 
 #define PAYLOAD_ADDRESS	0x23F00000
 
-#define BASE_PATH "/aurei/payloads/"
-#define PAYLOAD_PATH(x) BASE_PATH x ".bin"
+#define SHORT_PATTERN(x) x ".bin"
+#define LONG_PATTERN(x) x "_*.bin"
 
-static u32 loadPayload(const char *path)
+#define BASE_PATH "/aurei/payloads"
+#define PAYLOAD_PATH(x) BASE_PATH "/" SHORT_PATTERN(x)
+#define LOAD_PAYLOAD(x) loadPayload(SHORT_PATTERN(x), LONG_PATTERN(x))
+
+static u32 loadPath(const char *path)
 {
     FIL payload;
     unsigned int br;
@@ -23,6 +28,30 @@ static u32 loadPayload(const char *path)
     return 0;
 }
 
+static u32 findFile(const char *pattern)
+{
+    DIR dp;
+    static FILINFO fno;
+    FRESULT fr = f_findfirst(&dp, &fno, BASE_PATH, pattern);
+    if(!(fr == FR_OK && fno.fname[0])) {
+        f_closedir(&dp);
+        return 0;
+    }
+    static char payloadPath[80];
+    *payloadPath = '\0';
+    strcat(payloadPath, BASE_PATH);
+    strcat(payloadPath, "/");
+    strcat(payloadPath, fno.fname);
+    u32 result = loadPath(payloadPath);
+    f_closedir(&dp);
+    return result;
+}
+
+static u32 loadPayload(const char *short_pattern, const char *long_pattern) 
+{
+    return findFile(short_pattern) || findFile(long_pattern);
+}
+
 void main(void)
 {
     FATFS fs;
@@ -32,14 +61,14 @@ void main(void)
     //Get pressed buttons
     u32 pressed = HID_PAD;
 
-    if(((pressed & BUTTON_RIGHT) && loadPayload(PAYLOAD_PATH("right"))) ||
-       ((pressed & BUTTON_LEFT) && loadPayload(PAYLOAD_PATH("left"))) ||
-       ((pressed & BUTTON_UP) && loadPayload(PAYLOAD_PATH("up"))) ||
-       ((pressed & BUTTON_DOWN) && loadPayload(PAYLOAD_PATH("down"))) ||
-       ((pressed & BUTTON_X) && loadPayload(PAYLOAD_PATH("x"))) ||
-       ((pressed & BUTTON_Y) && loadPayload(PAYLOAD_PATH("y"))) ||
-       ((pressed & BUTTON_SELECT) && loadPayload(PAYLOAD_PATH("select"))) ||
-       ((pressed & BUTTON_R1) && loadPayload(PAYLOAD_PATH("r"))) ||
-       loadPayload(PAYLOAD_PATH("default")))
+    if(((pressed & BUTTON_RIGHT) && LOAD_PAYLOAD("right")) ||
+       ((pressed & BUTTON_LEFT) && LOAD_PAYLOAD("left")) ||
+       ((pressed & BUTTON_UP) && LOAD_PAYLOAD("up")) ||
+       ((pressed & BUTTON_DOWN) && LOAD_PAYLOAD("down")) ||
+       ((pressed & BUTTON_X) && LOAD_PAYLOAD("x")) ||
+       ((pressed & BUTTON_Y) && LOAD_PAYLOAD("y")) ||
+       ((pressed & BUTTON_R1) && LOAD_PAYLOAD("r")) ||
+       LOAD_PAYLOAD("def") ||
+       loadPath(PAYLOAD_PATH("default")))
         ((void (*)())PAYLOAD_ADDRESS)();
 }

--- a/source/fatfs/ffconf.h
+++ b/source/fatfs/ffconf.h
@@ -34,7 +34,7 @@
 /  2: Enable with LF-CRLF conversion. */
 
 
-#define _USE_FIND		0
+#define _USE_FIND		1
 /* This option switches filtered directory read feature and related functions,
 /  f_findfirst() and f_findnext(). (0:Disable or 1:Enable) */
 

--- a/source/fs.c
+++ b/source/fs.c
@@ -8,6 +8,8 @@
 #include "memory.h"
 #include "fatfs/ff.h"
 
+#define PAYLOAD_FOLDER "/aurei/payloads"
+
 static FATFS sdFs,
              nandFs;
 
@@ -75,6 +77,20 @@ u32 fileExists(const char *path)
 
     return exists;
 }
+
+u32 payloadFileExistsPattern(const char *folder, const char *pattern) {
+    static FILINFO fno;
+    DIR dp;
+    u32 result = f_findfirst(&dp, &fno, folder, pattern) == FR_OK && fno.fname[0];
+    f_closedir(&dp);
+    return result;
+}
+
+u32 payloadFileExists(const char *shortPattern, const char *longPattern)
+{
+    return payloadFileExistsPattern(PAYLOAD_FOLDER, shortPattern) || payloadFileExistsPattern(PAYLOAD_FOLDER, longPattern);
+}
+
 
 void firmRead(void *dest, const char *firmFolder)
 {

--- a/source/fs.h
+++ b/source/fs.h
@@ -14,3 +14,4 @@ u32 fileWrite(const void *buffer, const char *path, u32 size);
 u32 fileSize(const char *path);
 u32 fileExists(const char *path);
 void firmRead(void *dest, const char *firmFolder);
+u32 payloadFileExists(const char *shortPattern, const char *longPattern);

--- a/source/loader.c
+++ b/source/loader.c
@@ -14,7 +14,7 @@
 
 void loadPayload(void)
 {
-    if(fileExists("aurei/payloads/default.bin"))
+    if(payloadFileExists("default.bin", "def_*.bin"))
     {
         initScreens();
         memcpy((void *)PAYLOAD_ADDRESS, loader, loader_size);


### PR DESCRIPTION
Example: "x_decrypt9.bin"
Useful for keeping track of which payload is mapped to where. The "default.bin" takes the form of "def_ANYTHING.bin", due to a limitation in fatfs that doesn't allow search patterns to be more than 12 characters (including null terminator). At least that's what I concluded. This should be fixable by modifying the fatfs lib, but it felt too drastic.

Removed select button from payload loader as this is taken care of earlier in the boot process.
