### PR TITLE
Disable the SVC access permission checks in the kernel.

### DIFF
--- a/source/firm.c
+++ b/source/firm.c
@@ -313,6 +313,9 @@ static inline void patchNativeFirm(FirmwareSource nandType, u32 emuHeader, A9LHM
 
         //Does nothing if svcBackdoor is still there
         reimplementSvcBackdoor((u8 *)firm + section[1].offset, section[1].size);
+
+        //Remove the svc access checks
+        patchSvcAccessChecks((u8*)firm + section[1].offset, section[1].size);
     }
 }
 

--- a/source/patches.c
+++ b/source/patches.c
@@ -79,6 +79,16 @@ void patchFirmWriteSafe(u8 *pos, u32 size)
     off[1] = writeBlockSafe[1];
 }
 
+void patchSvcAccessChecks(u8* pos, u32 size)
+{
+    const u8 pattern[] = {0xEA, 0xFF, 0xFF, 0x0A};
+
+    u32* off = (u32*)memsearch(pos, pattern, size, 4);
+    
+    // Patch the access check to a NOP
+    *off = 0xE320F000;
+}
+
 void reimplementSvcBackdoor(u8 *pos, u32 size)
 {
     //Official implementation of svcBackdoor

--- a/source/patches.h
+++ b/source/patches.h
@@ -22,5 +22,6 @@ void patchFirmlaunches(u8 *pos, u32 size, u32 process9MemAddr);
 void patchFirmWrites(u8 *pos, u32 size);
 void patchFirmWriteSafe(u8 *pos, u32 size);
 void reimplementSvcBackdoor(u8 *pos, u32 size);
+void patchSvcAccessChecks(u8* pos, u32 size);
 void applyLegacyFirmPatches(u8 *pos, FirmwareType firmType, u32 isN3DS);
 u32 getLoader(u8 *pos, u32 *loaderSize);


### PR DESCRIPTION
You can now use any svc without having to make a CIA.
The pattern was taken from reversing a 4.5 kernel image and was tested in an 11.x system. 
It patches a BEQ to a NOP such that the permissions are ignored.
