### PR TITLE
Allow PIN entry splash images

### DIFF
--- a/source/draw.c
+++ b/source/draw.c
@@ -37,8 +37,8 @@ bool loadSplash(void)
     const char topSplashPath[] = "/luma/splash.bin",
                bottomSplashPath[] = "/luma/splashbottom.bin";
 
-    bool isTopSplashValid = getFileSize(topSplashPath) == SCREEN_TOP_FBSIZE,
-         isBottomSplashValid = getFileSize(bottomSplashPath) == SCREEN_BOTTOM_FBSIZE;
+    bool isTopSplashValid = verifyImage(topSplashPath, false);
+    bool isBottomSplashValid = verifyImage(bottomSplashPath, true);
 
     //Don't delay boot nor init the screens if no splash images or invalid splash images are on the SD
     if(!isTopSplashValid && !isBottomSplashValid)
@@ -46,12 +46,25 @@ bool loadSplash(void)
 
     initScreens();
 
-    if(isTopSplashValid) fileRead(fb->top_left, topSplashPath, 0);
-    if(isBottomSplashValid) fileRead(fb->bottom, bottomSplashPath, 0);
-
+    drawImages(topSplashPath, bottomSplashPath);
+    
     chrono(3);
 
     return true;
+}
+
+bool verifyImage(char* imagePath, bool bottomScreen)
+{
+  if (bottomScreen)
+    return getFileSize(imagePath) == SCREEN_BOTTOM_FBSIZE;
+  else
+    return getFileSize(imagePath) == SCREEN_TOP_FBSIZE;
+}
+
+void drawImages(char* topImagePath, char* bottomImagePath)
+{
+  fileRead(fb->top_left, topImagePath, 0);
+  fileRead(fb->bottom, bottomImagePath, 0);
 }
 
 void drawCharacter(char character, bool isTopScreen, u32 posX, u32 posY, u32 color)

--- a/source/draw.h
+++ b/source/draw.h
@@ -45,5 +45,7 @@
 #define COLOR_YELLOW 0x00FFFF
 
 bool loadSplash(void);
+bool verifyImage(char* imagePath, bool bottomScreen);
+void drawImages(char* topImagePath, char* bottomImagePath);
 void drawCharacter(char character, bool isTopScreen, u32 posX, u32 posY, u32 color);
 u32 drawString(const char *string, bool isTopScreen, u32 posX, u32 posY, u32 color);

--- a/source/pin.c
+++ b/source/pin.c
@@ -124,7 +124,13 @@ bool verifyPin(u32 pinMode)
     if(memcmp(pin.testHash, tmp, sizeof(tmp)) != 0) return false;
 
     initScreens();
-
+    
+    const char bottomSplashPath[] = "/luma/pinsplashbottom.bin", topSplashPath[] = "/luma/pinsplash.bin";
+    bool isTopSplashValid = verifyImage(topSplashPath, false);
+    bool isBottomSplashValid = verifyImage(bottomSplashPath, true);
+    if (isTopSplashValid && isBottomSplashValid)
+        drawImages(topSplashPath, bottomSplashPath);
+    
     //Pad to AES block length with zeroes
     u8 __attribute__((aligned(4))) enteredPassword[AES_BLOCK_SIZE] = {0};
 


### PR DESCRIPTION
Refactoring and initial code version to allow splash images for the PIN entry screens. Uses the same format as main splash screens, but files named pinsplash.bin and pinsplashbottom.bin.
TODO: keep splash image on-screen after incorrect PIN entry.
![qvv67u0](https://cloud.githubusercontent.com/assets/2762672/18685691/1eb72614-7f47-11e6-87b7-a001c8ccd810.jpg)
