### PR TITLE
Added a patch to disable DLP region check

### DIFF
--- a/injector/source/patcher.c
+++ b/injector/source/patcher.c
@@ -731,6 +731,24 @@ void patchCode(u64 progId, u16 progVer, u8 *code, u32 size)
            ) != 3) goto error;
     }
 
+    else if(progId == 0x0004013000002802LL && progVer > 0) //DLP
+    {
+        static const u8 pattern[] = {
+            0x0C, 0xAC, 0xC0, 0xD8
+        },
+                        patch[] = {
+            0x00, 0x00, 0x00, 0x00
+        };
+		
+		//Patch DLP region checks
+        if(!patchMemory(code, size,
+                pattern,
+                sizeof(pattern), 0,
+                patch,
+                sizeof(patch), 1
+            )) goto error;
+	}
+   
     if(CONFIG(PATCHGAMES) && (u32)((progId >> 0x20) & 0xFFFFFFEDULL) == 0x00040000)
     {
         u8 regionId = 0xFF,

--- a/injector/source/patcher.c
+++ b/injector/source/patcher.c
@@ -739,15 +739,15 @@ void patchCode(u64 progId, u16 progVer, u8 *code, u32 size)
                         patch[] = {
             0x00, 0x00, 0x00, 0x00
         };
-		
-		//Patch DLP region checks
+
+        //Patch DLP region checks
         if(!patchMemory(code, size,
                 pattern,
                 sizeof(pattern), 0,
                 patch,
                 sizeof(patch), 1
             )) goto error;
-	}
+    }
    
     if(CONFIG(PATCHGAMES) && (u32)((progId >> 0x20) & 0xFFFFFFEDULL) == 0x00040000)
     {


### PR DESCRIPTION
This patches the DLP region checking, and allows systems to host an out-of-region local multiplayer game (even if they didn't care about Download Play).