### PR TITLE
Use .text segment padding for LayeredFS payload

### DIFF
--- a/injector/source/loader.c
+++ b/injector/source/loader.c
@@ -158,7 +158,7 @@ static Result load_code(u64 progid, prog_addrs_t *shared, u64 prog_handle, int i
   u16 progver = g_exheader.codesetinfo.flags.remasterversion[0] | (g_exheader.codesetinfo.flags.remasterversion[1] << 8);
 
   // patch
-  patchCode(progid, progver, (u8 *)shared->text_addr, shared->total_size << 12);
+  patchCode(progid, progver, (u8 *)shared->text_addr, shared->total_size << 12, g_exheader.codesetinfo.text.codesize);
 
   return 0;
 }

--- a/injector/source/patcher.h
+++ b/injector/source/patcher.h
@@ -44,4 +44,4 @@ enum flags
     ISSAFEMODE
 };
 
-void patchCode(u64 progId, u16 progVer, u8 *code, u32 size);
+void patchCode(u64 progId, u16 progVer, u8 *code, u32 size, u32 text_size);


### PR DESCRIPTION
I moved the search for `throwFatalError` into a separate function and it checks for padding at the end of the .text segment first. If there's no room there then it searches for the function.

I also needed the actual size of the .text segment but the way I'm passing it through the `patchCode` function seems clunky.

Edit: It could also use some more testing. I tested it with the MHXX English patch and I tested it with MH4U with the padding section commented out (to make sure the `throwFatalError` method still works).

This is for somewhat fixing #400