### PR TITLE
Add config option to disable exception vectors.

### DIFF
--- a/source/config.c
+++ b/source/config.c
@@ -94,6 +94,7 @@ void configMenu(bool oldPinStatus, u32 oldPinMode)
                                         "( ) Show GBA boot screen in patched AGB_FIRM",
                                         "( ) Patch ARM9 access",
                                         "( ) Set developer UNITINFO",
+                                        "( ) Disable Exception Vectors",
                                       };
 
     const char *optionsDescription[]  = { "Select the default EmuNAND.\n\n"
@@ -187,6 +188,13 @@ void configMenu(bool oldPinStatus, u32 oldPinMode)
                                           "and booting some developer software).\n\n"
                                           "Only select this if you know what you\n"
                                           "are doing!",
+
+                                          "Disables the fatal error exception\n"
+                                          "vectors for the ARM11 CPU\n"
+                                          "Note: Disabling the exception vectors\n"
+                                          "will disqualify you from submitting\n"
+                                          "issues or bug reports to the Luma3DS\n"
+                                          "GitHub repository!"
                                        };
 
     struct multiOption {
@@ -209,6 +217,7 @@ void configMenu(bool oldPinStatus, u32 oldPinMode)
     } singleOptions[] = {
         { .visible = isSdMode },
         { .visible = isSdMode },
+        { .visible = true },
         { .visible = true },
         { .visible = true },
         { .visible = true },

--- a/source/config.h
+++ b/source/config.h
@@ -34,7 +34,7 @@
 
 #define CONFIG_FILE         "config.bin"
 #define CONFIG_VERSIONMAJOR 1
-#define CONFIG_VERSIONMINOR 12
+#define CONFIG_VERSIONMINOR 13
 
 #define BOOTCFG_NAND         BOOTCONFIG(0, 7)
 #define BOOTCFG_FIRM         BOOTCONFIG(3, 7)
@@ -58,7 +58,8 @@ enum singleOptions
     PATCHVERSTRING,
     SHOWGBABOOT,
     PATCHACCESS,
-    PATCHUNITINFO
+    PATCHUNITINFO,
+    DISABLEVECTORS
 };
 
 typedef enum ConfigurationStatus

--- a/sysmodules/rosalina/kernel_extension/include/config.h
+++ b/sysmodules/rosalina/kernel_extension/include/config.h
@@ -1,13 +1,13 @@
 #pragma once
 
-#include <3ds/types.h>
+#include "types.h"
 
 #define MAKE_BRANCH(src,dst)      (0xEA000000 | ((u32)((((u8 *)(dst) - (u8 *)(src)) >> 2) - 2) & 0xFFFFFF))
 #define MAKE_BRANCH_LINK(src,dst) (0xEB000000 | ((u32)((((u8 *)(dst) - (u8 *)(src)) >> 2) - 2) & 0xFFFFFF))
 
-#define CONFIG(a)        (((config >> (a + 17)) & 1) != 0)
-#define MULTICONFIG(a)   ((config >> (a * 2 + 7)) & 3)
-#define BOOTCONFIG(a, b) ((config >> a) & b)
+#define CONFIG(a)        (((cfwInfo.config >> (a + 17)) & 1) != 0)
+#define MULTICONFIG(a)   ((cfwInfo.config >> (a * 2 + 7)) & 3)
+#define BOOTCONFIG(a, b) ((cfwInfo.config >> a) & b)
 
 #define BOOTCFG_NAND         BOOTCONFIG(0, 7)
 #define BOOTCFG_FIRM         BOOTCONFIG(3, 7)
@@ -34,5 +34,3 @@ enum singleOptions
     PATCHUNITINFO,
     DISABLEVECTORS
 };
-
-void patchCode(u64 progId, u16 progVer, u8 *code, u32 size, u32 textSize, u32 roSize, u32 dataSize, u32 roAddress, u32 dataAddress);

--- a/sysmodules/rosalina/kernel_extension/include/globals.h
+++ b/sysmodules/rosalina/kernel_extension/include/globals.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include "config.h"
 #include "kernel.h"
 
 extern KRecursiveLock *criticalSectionLock;

--- a/sysmodules/rosalina/kernel_extension/source/fatalExceptionHandlersMain.c
+++ b/sysmodules/rosalina/kernel_extension/source/fatalExceptionHandlersMain.c
@@ -35,6 +35,8 @@
 
 bool isExceptionFatal(u32 spsr, u32 *regs, u32 index)
 {
+    if (CONFIG(DISABLEVECTORS)) return false;
+    
     if((spsr & 0x1f) != 0x10) return true;
 
     KThread *thread = currentCoreContext->objectContext.currentThread;


### PR DESCRIPTION
Adds an option to luma config to disable the fatal error exception vectors.

Implemented by adding "config.h" to Rosalina, that grabs the config entry from cfwInfo.