### PR TITLE
Don't fix already transformed $DEVKITARM variable

### DIFF
--- a/exceptions/exception_dump_parser.py
+++ b/exceptions/exception_dump_parser.py
@@ -162,8 +162,9 @@ if __name__ == "__main__":
     objdump_res = ""
     try:
         path = os.path.join(os.environ["DEVKITARM"], "bin", "arm-none-eabi-objdump")
-        if os.name == "nt":
-            path = ''.join((path[1], ':', path[2:])).replace('/', '\\')
+
+        if os.name == "nt" and path[0] == '/':
+			path = ''.join((path[1], ':', path[2:]))
 
         objdump_res = subprocess.check_output((
                                                     path, "-marm", "-b", "binary",


### PR DESCRIPTION
Windows doesn't need the slashes transformed, it's only cmd that''s bothered about which way round they are.

Under msys2 shell environment variables containing paths get transformed to windows paths when launching non msys2 applications. If the parser is  run from that shell then $DEVKITARM will already be c:/devkitPro/devkitARM. 