### PR TITLE
Custom mapping only available in Unsafe Mode to avoid a Precise Exter…

### DIFF
--- a/sysmodules/rosalina/include/gdb/server.h
+++ b/sysmodules/rosalina/include/gdb/server.h
@@ -37,6 +37,7 @@ typedef struct GDBServer
     sock_server super;
     s32 referenceCount;
     Handle statusUpdated;
+    bool isUnsafeModeEnabled;
     GDBContext ctxs[MAX_DEBUG];
 } GDBServer;
 

--- a/sysmodules/rosalina/include/menus/debugger.h
+++ b/sysmodules/rosalina/include/menus/debugger.h
@@ -33,3 +33,4 @@ extern Menu debuggerMenu;
 
 void DebuggerMenu_EnableDebugger(void);
 void DebuggerMenu_DisableDebugger(void);
+void DebuggerMenu_ToggleUnsafeMode(void);

--- a/sysmodules/rosalina/source/menus/debugger.c
+++ b/sysmodules/rosalina/source/menus/debugger.c
@@ -36,10 +36,11 @@
 
 Menu debuggerMenu = {
     "Debugger options menu",
-    .nbItems = 2,
+    .nbItems = 3,
     {
         { "Enable debugger",  METHOD, .method = &DebuggerMenu_EnableDebugger  },
-        { "Disable debugger", METHOD, .method = &DebuggerMenu_DisableDebugger }
+        { "Disable debugger", METHOD, .method = &DebuggerMenu_DisableDebugger },
+        { "Enable unsafe mode", METHOD, .method = &DebuggerMenu_ToggleUnsafeMode }
     }
 };
 
@@ -148,6 +149,20 @@ void DebuggerMenu_DisableDebugger(void)
         Draw_Unlock();
     }
     while(!(waitInput() & BUTTON_B) && !terminationRequest);
+}
+
+void DebuggerMenu_ToggleUnsafeMode(void)
+{
+    if (gdbServer.isUnsafeModeEnabled)
+    {
+        gdbServer.isUnsafeModeEnabled = false;
+        debuggerMenu.items[2].title = "Enable unsafe mode";
+    }
+    else
+    {
+        gdbServer.isUnsafeModeEnabled = true;
+        debuggerMenu.items[2].title = "Disable unsafe mode";
+    }
 }
 
 void debuggerSocketThreadMain(void)


### PR DESCRIPTION
…nal Abort

IDA considers every values as potentials addresses and tries to access them to give a preview of the address's value.
Problem is that if the value/address isn't part of the process, Luma will try to access it with the custom mapping.
This often triggers a Precise External Abort which is annoying and I don't think that it should be a feature enabled by default.

Having it disabled by default but give the user the possibility to enable it seems to be a good compromise.