### PR TITLE
InputRedirection: fix freeze and improve stability

### DIFF
--- a/sysmodules/rosalina/include/menu.h
+++ b/sysmodules/rosalina/include/menu.h
@@ -71,7 +71,9 @@ typedef struct Menu {
 } Menu;
 
 extern bool terminationRequest;
+extern bool isSleeping;
 extern Handle terminationRequestEvent;
+extern LightEvent onWakeUpEvent;
 
 extern u32 menuCombo;
 

--- a/sysmodules/rosalina/include/utils.h
+++ b/sysmodules/rosalina/include/utils.h
@@ -56,4 +56,5 @@ static inline void *decodeARMBranch(const void *src)
     return (void *)((const u8 *)src + 8 + off);
 }
 
-Result OpenProcessByName(const char *name, Handle *h);
+Result  OpenProcessByName(const char *name, Handle *h);
+bool    Wifi_IsConnected(void);

--- a/sysmodules/rosalina/source/menu.c
+++ b/sysmodules/rosalina/source/menu.c
@@ -166,6 +166,10 @@ void menuThreadMain(void)
                 menuLeave();
             }
         }
+
+        if(isSleeping && !terminationRequest)
+            LightEvent_Wait(&onWakeUpEvent);
+
         svcSleepThread(50 * 1000 * 1000LL);
     }
 }
@@ -335,5 +339,5 @@ void menuShow(Menu *root)
         menuDraw(currentMenu, selectedItem);
         Draw_Unlock();
     }
-    while(!terminationRequest);
+    while(!terminationRequest && !isSleeping);
 }

--- a/sysmodules/rosalina/source/menus/debugger.c
+++ b/sysmodules/rosalina/source/menus/debugger.c
@@ -88,6 +88,8 @@ void DebuggerMenu_EnableDebugger(void)
             Draw_DrawString(10, 30, COLOR_WHITE, "Already enabled!");
         else if(!isSocURegistered)
             Draw_DrawString(10, 30, COLOR_WHITE, "Can't start the debugger before the system has fi-\nnished loading.");
+        else if(!Wifi_IsConnected())
+            Draw_DrawString(10, 30, COLOR_WHITE, "Can't start the debugger if the system is not\nconnected to Internet.");
         else
         {
             Draw_DrawString(10, 30, COLOR_WHITE, "Starting debugger...");


### PR DESCRIPTION
- Check for Internet connection before launching the Input Redirection
- Check if the 3DS is going to sleep (through notifications) to pause the threads (close Rosalina menu if open when going to sleep)
- If the Input Redirection is enabled and the 3DS is disconnected from Internet, the Input Redirection will auto exit and wait until the 3DS is connected again before restarting the Input Redirection
- Changed when the patchs are applied as you could remove them when you wanted to apply them and vice-versa depending on the errors you had

Should fix #648, #904 and #935  (maybe #812 too but it seems like there's no particular way to test those reports, so I can't be sure).