### PR TITLE
Removed links to compiled armips and makerom

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Since Luma3DS v8.0, Luma3DS has its own in-game menu, triggerable by `L+Down+Sel
 First you need to clone the repository with: `git clone https://github.com/AuroraWright/Luma3DS.git`  
 To compile, you'll need [armips](https://github.com/Kingcom/armips) and a build of a recent commit of [makerom](https://github.com/profi200/Project_CTR) added to your PATH. You'll also need to install [firmtool](https://github.com/TuxSH/firmtool), its README contains installation instructions.
 You'll also need to update your [libctru](https://github.com/smealum/ctrulib) install, building from the latest commit.  
-Here are [Windows](https://buildbot.orphis.net/armips/) and [Linux](https://mega.nz/#!uQ1T1IAD!Q91O0e12LXKiaXh_YjXD3D5m8_W3FuMI-hEa6KVMRDQ) builds of armips (thanks to who compiled them!) and [makerom](https://github.com/Steveice10/buildtools/tree/master/3ds) (thanks @Steveice10!).   
+Here are [Windows](https://buildbot.orphis.net/armips/) builds of armips (thanks to who compiled them!). For armips on Linux, there is an [AUR](https://aur.archlinux.org/packages/armips-git/) package available.
 Run `make` and everything should work!  
 You can find the compiled files in the `out` folder.
 


### PR DESCRIPTION
The mega link for linux armips 404's and makerom is no longer supplied in buildtools due to a change by steveice10.

Removed the compiled makerom links entirely and replaced linux armips with a link to the armips-git package on the AUR.