### PR TITLE
Remove AUR package from prebuilds.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Since Luma3DS v8.0, Luma3DS has its own in-game menu, triggerable by `L+Down+Sel
 First you need to clone the repository with: `git clone https://github.com/AuroraWright/Luma3DS.git`  
 To compile, you'll need [armips](https://github.com/Kingcom/armips) and a build of a recent commit of [makerom](https://github.com/profi200/Project_CTR) added to your PATH. You'll also need to install [firmtool](https://github.com/TuxSH/firmtool), its README contains installation instructions.
 You'll also need to update your [libctru](https://github.com/smealum/ctrulib) install, building from the latest commit.  
-Here are [Windows](https://buildbot.orphis.net/armips/) builds of armips (thanks to who compiled them!). For armips on Linux, there is an [AUR](https://aur.archlinux.org/packages/armips-git/) package available.
+Here are [Windows](https://buildbot.orphis.net/armips/) and [Linux](https://ev1l0rd.s-ul.eu/mEIk4atQ) builds of armips (thanks to who compiled them!).
 Run `make` and everything should work!  
 You can find the compiled files in the `out` folder.
 


### PR DESCRIPTION
Ater discussion with @Hikari-chin (and some other people), I've come to the conclusion that it's not a wise idea to link to an AUR package in the README.

That said, it might still be useful to provide a compiled version of armips for Linux as Windows builds are also provided. To this extent I've compiled armips for both x86 and x86_64 architectures (available in the zip file linked in the commit, or [here](https://ev1l0rd.s-ul.eu/mEIk4atQ) if you dont wish to open the commit). (It's possible to identify the binary arch with the `file` command if one wishes to verify I did this properly).