### PR TITLE
Fixed cheat functionality

### DIFF
--- a/sysmodules/rosalina/source/menus/cheats.c
+++ b/sysmodules/rosalina/source/menus/cheats.c
@@ -468,7 +468,9 @@ static u32 Cheat_ApplyCheat(const Handle processHandle, const CheatDescription* 
                 // Description: Loads offset register.
                 if (!skipExecution)
                 {
-                    cheat_state.offset = (arg0 & 0x0FFFFFFF);
+					u32 value;
+					if (!Cheat_Read32(processHandle, arg0 & 0x0FFFFFFF, &value)) return 0;
+					cheat_state.offset = value;
                 }
                 break;
             case 0xC:

--- a/sysmodules/rosalina/source/menus/cheats.c
+++ b/sysmodules/rosalina/source/menus/cheats.c
@@ -468,9 +468,9 @@ static u32 Cheat_ApplyCheat(const Handle processHandle, const CheatDescription* 
                 // Description: Loads offset register.
                 if (!skipExecution)
                 {
-					u32 value;
-					if (!Cheat_Read32(processHandle, arg0 & 0x0FFFFFFF, &value)) return 0;
-					cheat_state.offset = value;
+                    u32 value;
+                    if (!Cheat_Read32(processHandle, arg0 & 0x0FFFFFFF, &value)) return 0;
+                    cheat_state.offset = value;
                 }
                 break;
             case 0xC:


### PR DESCRIPTION
The BXXXXXXX code for Gateshark was made so you could read pointers with your cheat codes, as some games store certain values in randomly assigned memory.

The original submission by TuxSH had the BXXXXXXX code do the same thing as the D300000 code. That is, to simply load the offset register with some value.

Hope this fix helps people get their codes working. Mine worked beautifully after the change!