### PR TITLE
Fixed cheat functionality

### DIFF
--- a/sysmodules/rosalina/include/menus/cheats.h
+++ b/sysmodules/rosalina/include/menus/cheats.h
@@ -33,4 +33,4 @@
 #define CHEATS_PER_MENU_PAGE 18
 
 void RosalinaMenu_Cheats(void);
-void Cheat_ApplyKeyCheats();
+void Cheat_ApplyCheats();

--- a/sysmodules/rosalina/source/menu.c
+++ b/sysmodules/rosalina/source/menu.c
@@ -169,7 +169,7 @@ void menuThreadMain(void)
         }
         else
         {
-        	Cheat_ApplyCheats();
+            Cheat_ApplyCheats();
         }
         svcSleepThread(50 * 1000 * 1000LL);
     }

--- a/sysmodules/rosalina/source/menu.c
+++ b/sysmodules/rosalina/source/menu.c
@@ -169,9 +169,7 @@ void menuThreadMain(void)
         }
         else
         {
-        	if (HID_PAD & 0xFFF) {
-        		Cheat_ApplyKeyCheats();
-        	}
+        	Cheat_ApplyCheats();
         }
         svcSleepThread(50 * 1000 * 1000LL);
     }

--- a/sysmodules/rosalina/source/menus/cheats.c
+++ b/sysmodules/rosalina/source/menus/cheats.c
@@ -465,7 +465,7 @@ static u32 Cheat_ApplyCheat(const Handle processHandle, const CheatDescription* 
             case 0xB:
                 // B Type
                 // Format: BXXXXXXX 00000000
-                // Description: Loads offset register.
+                // Description: Loads offset register with value at given XXXXXXX
                 if (!skipExecution)
                 {
                     u32 value;

--- a/sysmodules/rosalina/source/menus/cheats.c
+++ b/sysmodules/rosalina/source/menus/cheats.c
@@ -1120,13 +1120,9 @@ static u32 Cheat_GetCurrentPID(u64* titleId)
     }
 }
 
-void Cheat_ApplyKeyCheats(void)
+void Cheat_ApplyCheats(void)
 {
     if (!cheatCount)
-    {
-        return;
-    }
-    if (!hasKeyActivated)
     {
         return;
     }
@@ -1151,9 +1147,13 @@ void Cheat_ApplyKeyCheats(void)
     u32 keys = HID_PAD & 0xFFF;
     for (int i = 0; i < cheatCount; i++)
     {
-        if (cheats[i]->active && cheats[i]->keyActivated && (cheats[i]->keyCombo & keys) == keys)
+        if (cheats[i]->active && !(cheats[i]->keyActivated))
         {
             Cheat_MapMemoryAndApplyCheat(pid, cheats[i]);
+        } 
+        else if (cheats[i]->active && cheats[i]->keyActivated && (cheats[i]->keyCombo & keys) == keys)
+        {
+            Cheat_MapMemoryAndApplyCheat(pid, cheats[i]);    
         }
     }
 }


### PR DESCRIPTION
Gateshark codes without key presses are intended to run forever. The way the code was previously written, only key combo cheats were run more than once, which breaks all sorts of infinite cheats like health, lives, magic, etc. 

I tested these code changes and it fixed gateshark functionality. No decrease in performance from running more cheats was observed in the several games I tried. Cheats that still require a button press still work as well from my previous pull request. 

The logic for renaming the function ApplyKeyCheats is simply that it now applies all cheats, as thats the point of this change.