### PR TITLE
Added Patch to Process9 11.8 to the new AMPXI function

### DIFF
--- a/source/firm.c
+++ b/source/firm.c
@@ -400,6 +400,9 @@ u32 patchNativeFirm(u32 firmVersion, FirmwareSource nandType, bool loadFromStora
     //Apply anti-anti-DG patches on 11.0+
     if(firmVersion >= (ISN3DS ? 0x21 : 0x52)) ret += patchTitleInstallMinVersionChecks(process9Offset, process9Size, firmVersion);
 
+    //patch P9 AM ticket wrapper on 11.8+ to use 0 Key and IV, only on UNITINFO patch to prevent NIM from actually send any
+    if(doUnitinfoPatch && firmVersion >= (ISN3DS ? 0x35 : 0x64)) ret += patchP9AMTicketWrapperZeroKeyIV(process9Offset, process9Size);
+
     //Apply UNITINFO patches
     if(doUnitinfoPatch)
     {

--- a/source/patches.c
+++ b/source/patches.c
@@ -668,3 +668,25 @@ u32 patchAgbBootSplash(u8 *pos, u32 size)
 
     return 0;
 }
+
+u32 patchP9AMTicketWrapperZeroKeyIV(u8* pos, u32 size)
+{
+    static const u8 __rt_memclr_pattern[] = {0x00, 0x20, 0xA0, 0xE3, 0x04, 0x00, 0x51, 0xE3, 0x07, 0x00, 0x00, 0x3A};
+    static const u8 pattern[] = {0x20, 0x21, 0xA6, 0xA8};
+
+    u32 function = (u32)memsearch(pos, __rt_memclr_pattern, size, sizeof(__rt_memclr_pattern));
+    u32 *off = (u32*)memsearch(pos, pattern, size, sizeof(pattern));
+
+    if(function == 0 || off == NULL) return 1;
+
+    s32 opjumpdistance = (s32)(function - ((u32)&off[2])) / 2;
+
+    //beyond limit
+    if(opjumpdistance < -0x1fffff || opjumpdistance > 0x1fffff) return 1;
+
+    //r0 and r1 for old call are already correctly for this one 
+    //BLX __rt_memclr
+    off[1] = 0xE800F000U | (((u32)opjumpdistance & 0x7FF) << 16) | (((u32)opjumpdistance >> 11) & 0x3FF) | (((u32)opjumpdistance >> 21) & 0x400);
+
+    return 0;
+}

--- a/source/patches.h
+++ b/source/patches.h
@@ -64,3 +64,4 @@ u32 patchTwlFlashcartChecks(u8 *pos, u32 size, u32 firmVersion);
 u32 patchOldTwlFlashcartChecks(u8 *pos, u32 size);
 u32 patchTwlShaHashChecks(u8 *pos, u32 size);
 u32 patchAgbBootSplash(u8 *pos, u32 size);
+u32 patchP9AMTicketWrapperZeroKeyIV(u8* pos, u32 size);


### PR DESCRIPTION
Patch it to call __rt_memclr instead of internal PRNG when generating Key
and IV.
Only if UNITINFO is set, preventing on regular console usage NIM sending
to nintendo a 0 Key and IV, and allowing nintendo to know who has a
patched console.
Edit, for details,
Allows an user through homebrew to export a decrypted ticket since the key is predictable.