### PR TITLE
Taking advantage of GitHubs new issue templates.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md.md
@@ -1,3 +1,8 @@
+---
+name: Bug report
+about: Use this to report bugs you encounter with Luma3DS. Make sure you upload the crash dumps if Luma3DS crashes.
+---
+
 <!--
 -- THIS IS NOT A SUPPORT FORUM! For support go here:
 -- Nintendo Homebrew: https://discord.gg/MjzatM8


### PR DESCRIPTION
Github recently changed the way issue templates work, permitting repositories to add more descriptive fields to issue templates as well as allowing for multiple templates.

This change the issue template to match this new method.

Advantages are that there is now an option to disable the template, as well as making it possible to add multiple for feature requests and so on.

Attached below are screenshots of this in action (done on my own fork, on which I enabled the issue tracker to take these screenshots, feel free to give it a look yourself: [This is where you end up after clicking "new issue"](https://github.com/noirscape/Luma3DS/issues/new/choose).) 

Clicking "Open a regular issue" gives you an issue with nothing in it.

![Before issue submission](https://i.catgirlsin.space/ed/00cb6d7ba4bd5e7cc945957a785bc92dc13d52.png)
![While making an issue](https://i.catgirlsin.space/7f/fa076f9dcac96dadaa21d4f283ecd4453889ba.png)