### PR TITLE
removing -flto flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ dir_build := build
 dir_out := out
 
 ASFLAGS := -mcpu=arm946e-s
-CFLAGS := -Wall -Wextra $(ASFLAGS) -fno-builtin -std=c11 -Wno-main -O2 -flto -ffast-math
+CFLAGS := -Wall -Wextra $(ASFLAGS) -fno-builtin -std=c11 -Wno-main -O2 -ffast-math
 LDFLAGS := -nostartfiles -Wl,--nmagic
 
 objects = $(patsubst $(dir_source)/%.s, $(dir_build)/%.o, \

--- a/k11_extension/Makefile
+++ b/k11_extension/Makefile
@@ -14,7 +14,7 @@ dir_build := build
 
 ARCH    := -mcpu=mpcore -mfpu=vfp
 ASFLAGS := $(ARCH)
-CFLAGS  := -Wall -Wextra -MMD -MP -marm $(ASFLAGS) -I$(dir_include) -fno-builtin -std=c11 -Wno-main -g -flto -O2 -ffast-math \
+CFLAGS  := -Wall -Wextra -MMD -MP -marm $(ASFLAGS) -I$(dir_include) -fno-builtin -std=c11 -Wno-main -g -O2 -ffast-math \
 -mword-relocations -ffunction-sections -fdata-sections
 LDFLAGS := -nostdlib -Wl,--gc-sections,--nmagic $(ARCH)
 


### PR DESCRIPTION
removing -flto to fix compiler error (windows 10 + gcc 8.2.1 (mingw) 12/12/2018)