### PR TITLE
IFile: Fix reading past the end of file

### DIFF
--- a/sysmodules/rosalina/source/ifile.c
+++ b/sysmodules/rosalina/source/ifile.c
@@ -71,7 +71,7 @@ Result IFile_Read(IFile *file, u64 *total, void *buffer, u32 len)
   while (1)
   {
     res = FSFILE_Read(file->handle, &read, file->pos, buf, left);
-    if (R_FAILED(res))
+    if (R_FAILED(res) || read == 0)
     {
       break;
     }


### PR DESCRIPTION
Apparently, reading past the end of the a file counts as a success for Nintendo, and doesn't even return a unique Result.