### PR TITLE
rosalina/gdb/server: Prevent potential null dereference case

### DIFF
--- a/sysmodules/rosalina/source/gdb/server.c
+++ b/sysmodules/rosalina/source/gdb/server.c
@@ -136,9 +136,9 @@ GDBContext *GDB_SelectAvailableContext(GDBServer *server, u16 minPort, u16 maxPo
     {
         ctx->flags |= GDB_FLAG_SELECTED;
         ctx->localPort = port;
+        ctx->parent = server;
     }
 
-    ctx->parent = server;
     GDB_UnlockAllContexts(server);
     return ctx;
 }


### PR DESCRIPTION
While unlikely to commonly occur, this is a trivially avoidable case.