### PR TITLE
sm/notifications: Prevent potential null pointer dereference in ReceiveNotification

### DIFF
--- a/sysmodules/sm/source/notifications.c
+++ b/sysmodules/sm/source/notifications.c
@@ -101,7 +101,7 @@ Result ReceiveNotification(SessionData *sessionData, u32 *notificationId)
 
     if(processData == NULL || !processData->notificationEnabled || processData->nbPendingNotifications == 0)
     {
-        if(processData->nbPendingNotifications)
+        if(processData != NULL && processData->nbPendingNotifications)
             *notificationId = 0;
         return 0xD8806404;
     }


### PR DESCRIPTION
Based off the conditions, this is a potential null pointer dereference that can occur. We need to check for null before accessing nbPendingNotifications.

This is unlikely to occur in common usage, however it's a fairly straightforward amendment.