### PR TITLE
rosalina/errdisp: Correct uninitialized variable usage in ERRF_HandleCommands

### DIFF
--- a/sysmodules/rosalina/source/errdisp.c
+++ b/sysmodules/rosalina/source/errdisp.c
@@ -273,7 +273,7 @@ void ERRF_HandleCommands(void *ctx)
             else
             {
                 cmdbuf[0] = 0x20040;
-                u32 sz = cmdbuf[1] <= 0x100 ? sz : 0x100;
+                u32 sz = cmdbuf[1] <= 0x100 ? cmdbuf[1] : 0x100;
                 memcpy(userString, cmdbuf + 3, sz);
                 userString[sz] = 0;
             }


### PR DESCRIPTION
This was previously using the value of the uninitialized `sz` variable before it was actually assigned a value, rather than assigning the size indicated within the command buffer.