### PR TITLE
Add patching ITCM with provided OTP to bypass console bans

### DIFF
--- a/arm9/source/itcm.c
+++ b/arm9/source/itcm.c
@@ -1,0 +1,28 @@
+#include "itcm.h"
+#include "fs.h"
+#include "utils.h"
+#include "memory.h"
+
+/* Patches the ITCM with the OTP provided,
+ * functionally bypassing error 022-2812.
+ */
+void patchITCM() {
+    Otp otp;
+    u32 otpSize = fileRead(&otp, OTP_PATH, sizeof(Otp));
+
+    // Error checking
+    if (otpSize != sizeof(Otp)) error("OTP is not the correct size.");
+    if (otp.magic != OTP_MAGIC) error("Unable to parse OTP. Is it decrypted properly?");
+
+    // Setting relevant values in memory to struct parsed from file
+    ARM9_ITCM->otp.deviceId = otp.deviceId;
+    ARM9_ITCM->otp.timestampYear = otp.timestampYear;
+    ARM9_ITCM->otp.timestampMonth = otp.timestampMonth;
+    ARM9_ITCM->otp.timestampDay = otp.timestampDay;
+    ARM9_ITCM->otp.timestampHour = otp.timestampHour;
+    ARM9_ITCM->otp.timestampMinute = otp.timestampMinute;
+    ARM9_ITCM->otp.timestampSecond = otp.timestampSecond;
+    ARM9_ITCM->otp.ctcertExponent = otp.ctcertExponent;
+    memcpy(ARM9_ITCM->otp.ctcertPrivK, otp.ctcertPrivK, sizeof(otp.ctcertPrivK));
+    memcpy(ARM9_ITCM->otp.ctcertSignature, otp.ctcertSignature, sizeof(otp.ctcertSignature));
+}

--- a/arm9/source/itcm.h
+++ b/arm9/source/itcm.h
@@ -1,0 +1,181 @@
+// From: https://github.com/d0k3/GodMode9/blob/master/arm9/source/system/itcm.h
+
+#pragma once
+
+// This file contains the structure of ITCM on the ARM9, as initialized by boot9.
+
+#include "memmap.h"
+#include "types.h"
+
+#define STATIC_ASSERT(...) \
+    _Static_assert((__VA_ARGS__), #__VA_ARGS__)
+
+// Structure of the decrypted version of the OTP.  Part of this is in ITCM.
+// https://www.3dbrew.org/wiki/OTP_Registers#Plaintext_OTP
+typedef struct _Otp {
+    // 00: Magic value OTP_MAGIC (little-endian).
+    u32 magic;
+    // 04: DeviceId, mostly used for TWL stuff.
+    u32 deviceId;
+    // 08: Fallback keyY for movable.sed.
+    u8 fallbackKeyY[16];
+    // 18: CtCert flags.  When >= 5, ctcertExponent is big-endian?  Always 05 in systems I've seen.
+    u8 ctcertFlags;
+    // 19: 00 = retail, nonzero (always 02?) = dev
+    u8 ctcertIssuer;
+    // 1A-1F: CtCert timestamp - can be used as timestamp of SoC.  Year is minus 1900.
+    u8 timestampYear;
+    u8 timestampMonth;
+    u8 timestampDay;
+    u8 timestampHour;
+    u8 timestampMinute;
+    u8 timestampSecond;
+    // 20: CtCert ECDSA exponent.  Big-endian if ctcertFlags >= 5?
+    u32 ctcertExponent;
+    // 24: CtCert ECDSA private key, in big-endian.  First two bytes always zero?
+    u8 ctcertPrivK[32];
+    // 44: CtCert ECDSA signature, in big-endian.  Proves CtCert was made by Nintendo.
+    u8 ctcertSignature[60];
+    // 80: Zero.
+    u8 zero[16];
+    // 90: Random(?) data used for generation of console-specific keys.
+    u8 random[0x50];
+    // E0: SHA-256 hash of the rest of OTP.
+    u8 hash[256 / 8];
+} __attribute__((__packed__)) Otp;
+
+// Value of Otp::magic
+#define OTP_MAGIC 0xDEADB00F
+// Value to add to Otp::timestampYear to get actual year.
+#define OTP_YEAR_BIAS 1900
+
+// Sanity checking.
+STATIC_ASSERT(offsetof(Otp, magic) == 0x00);
+STATIC_ASSERT(offsetof(Otp, deviceId) == 0x04);
+STATIC_ASSERT(offsetof(Otp, fallbackKeyY) == 0x08);
+STATIC_ASSERT(offsetof(Otp, ctcertFlags) == 0x18);
+STATIC_ASSERT(offsetof(Otp, ctcertIssuer) == 0x19);
+STATIC_ASSERT(offsetof(Otp, timestampYear) == 0x1A);
+STATIC_ASSERT(offsetof(Otp, timestampMonth) == 0x1B);
+STATIC_ASSERT(offsetof(Otp, timestampDay) == 0x1C);
+STATIC_ASSERT(offsetof(Otp, timestampHour) == 0x1D);
+STATIC_ASSERT(offsetof(Otp, timestampMinute) == 0x1E);
+STATIC_ASSERT(offsetof(Otp, timestampSecond) == 0x1F);
+STATIC_ASSERT(offsetof(Otp, ctcertExponent) == 0x20);
+STATIC_ASSERT(offsetof(Otp, ctcertPrivK) == 0x24);
+STATIC_ASSERT(offsetof(Otp, ctcertSignature) == 0x44);
+STATIC_ASSERT(offsetof(Otp, zero) == 0x80);
+STATIC_ASSERT(offsetof(Otp, random) == 0x90);
+STATIC_ASSERT(offsetof(Otp, hash) == 0xE0);
+STATIC_ASSERT(sizeof(Otp) == 256);
+
+
+// Structure of an RSA private key that boot9 puts into ITCM.
+// These keys were never used.
+typedef struct _Arm9ItcmRsaPrivateKey {
+    // 000: RSA modulus.
+    u8 modulus[256];
+    // 100: RSA private exponent.
+    u8 privateExponent[256];
+} __attribute__((__packed__)) Arm9ItcmRsaPrivateKey;
+
+STATIC_ASSERT(sizeof(Arm9ItcmRsaPrivateKey) == 512);
+
+
+// Structure of the data in ARM9 ITCM, filled in by boot9.
+// https://www.3dbrew.org/wiki/OTP_Registers#Plaintext_OTP
+typedef struct _Arm9Itcm {
+    // 0000: Uninitialized / available.
+    u8 uninitializedBefore[0x3700];
+    // 3700: Copied code from boot9 to disable boot9.
+    u8 boot9DisableCode[0x100];
+    // 3800: Decrypted OTP.  boot9 zeros last 0x70 bytes (Otp::random and Otp::hash).
+    Otp otp;
+    // 3900: Copy of NAND MBR, which includes the NCSD header.
+    u8 ncsd[0x200];
+    // 3B00: Decrypted FIRM header for the FIRM that was loaded by boot9.
+    u8 decryptedFirmHeader[0x200];
+    // 3D00: RSA modulus for keyslots 0-3 as left by boot9 (big-endian).
+    u8 rsaKeyslotModulus[4][0x100];
+    // 4100: RSA private keys for who knows what; nothing ever used them.
+    Arm9ItcmRsaPrivateKey rsaPrivateKeys[4];
+    // 4900: RSA public keys (moduli) for things Nintendo signs.
+    u8 rsaModulusCartNCSD[0x100];
+    u8 rsaModulusAccessDesc[0x100];
+    u8 rsaModulusUnused2[0x100];
+    u8 rsaModulusUnused3[0x100];
+    // 4D00: Unknown keys; unused.
+    u8 unknownKeys[8][16];
+    // 4D80: NAND CID
+    u8 nandCid[0x64];
+    // 4DE4: Padding after NAND CID; uninitialized.
+    u8 uninitializedCid[0x1C];
+    // 4E00: Unused data before TWL keys.
+    u8 uninitializedMiddle[0x200];
+    // 5000: RSA modulus for TWL System Menu.
+    u8 rsaModulusTwlSystemMenu[0x80];
+    // 5080: RSA modulus for TWL Wi-Fi firmware and DSi Sound.
+    u8 rsaModulusTwlSound[0x80];
+    // 5100: RSA modulus for TWL system applications.
+    u8 rsaModulusTwlSystemApps[0x80];
+    // 5180: RSA modulus for TWL normal applications.
+    u8 rsaModulusTwlNormalApps[0x80];
+    // 5200: TWL ???
+    u8 twlUnknown1[0x10];
+    // 5210: TWL keyY for per-console ES blocks.
+    u8 twlKeyYUniqueES[0x10];
+    // 5220: TWL keyY for fixed-key ES blocks.
+    u8 twlKeyYFixedES[0x10];
+    // 5230: TWL ???
+    u8 twlUnknown2[0xD0];
+    // 5300: TWL common key.
+    u8 twlCommonKey[0x10];
+    // 5310: TWL ???
+    u8 twlUnknown3[0x40];
+    // 5350: TWL normal key for keyslot 0x02.
+    u8 twlKeyslot02NormalKey[0x10];
+    // 5360: TWL ???
+    u8 twlUnknown4[0x20];
+    // 5380: TWL keyX for keyslot 0x00.
+    u8 twlKeyslot00KeyX[0x10];
+    // 5390: TWL ???
+    u8 twlUnknown5[8];
+    // 5398: TWL "Tad" crypto keyX.
+    u8 twlTadKeyX[0x10];
+    // 53A8: TWL middle two words of keyslot 0x03 keyX.
+    u8 twlKeyslot03KeyXMiddle[8];
+    // 53B0: TWL ???
+    u8 twlUnknown6[12];
+    // 53BC: TWL keyY for keyslot 0x01.  Truncated (last word becomes E1A00005).
+    u8 twlKeyslot01KeyY[12];
+    // 53C8: TWL keyY for NAND crypto on retail TWL.
+    u8 twlNANDKeyY[0x10];
+    // 53D8: TWL ???
+    u8 twlUnknown7[8];
+    // 53E0: TWL Blowfish cart key.
+    u8 twlBlowfishCartKey[0x1048];
+    // 6428: NTR Blowfish cart key.
+    u8 ntrBlowfishCartKey[0x1048];
+    // 7470: End of the line.
+    u8 uninitializedEnd1[0x790];
+    // 7C00: ...But wait, this buffer is used for the FIRM header during firmlaunch on >= 9.5.0.
+    u8 firmlaunchHeader[0x100];
+    // 7D00: Back to our regularly-scheduled emptiness.
+    u8 uninitializedEnd2[0x300];
+} __attribute__((__packed__)) Arm9Itcm;
+
+// Sanity checking.
+STATIC_ASSERT(offsetof(Arm9Itcm, otp) == 0x3800);
+STATIC_ASSERT(offsetof(Arm9Itcm, twlNANDKeyY) == 0x53C8);
+STATIC_ASSERT(offsetof(Arm9Itcm, twlBlowfishCartKey) == 0x53E0);
+STATIC_ASSERT(offsetof(Arm9Itcm, ntrBlowfishCartKey) == 0x6428);
+STATIC_ASSERT(sizeof(Arm9Itcm) == 0x8000);
+
+
+// Macro for accessing ITCM.
+#define ARM9_ITCM ((Arm9Itcm*) __ITCM_ADDR)
+
+// Default path for the OTP is in the base directory of Luma.
+#define OTP_PATH "otp.bin"
+
+void patchITCM();

--- a/arm9/source/main.c
+++ b/arm9/source/main.c
@@ -37,6 +37,7 @@
 #include "memory.h"
 #include "screen.h"
 #include "i2c.h"
+#include "itcm.h"
 #include "fatfs/sdmmc/sdmmc.h"
 
 extern u8 __itcm_start__[], __itcm_lma__[], __itcm_bss_start__[], __itcm_end__[];
@@ -117,6 +118,7 @@ void main(int argc, char **argv, u32 magicWord)
     memcpy(__itcm_start__, __itcm_lma__, __itcm_bss_start__ - __itcm_start__);
     memset(__itcm_bss_start__, 0, __itcm_end__ - __itcm_bss_start__);
     I2C_init();
+
     if(isInvalidLoader) error("Launched using an unsupported loader.");
 
     installArm9Handlers();
@@ -157,6 +159,9 @@ void main(int argc, char **argv, u32 magicWord)
     }
 
     detectAndProcessExceptionDumps();
+
+    // Writes plaintext OTP to ITCM, if OTP exists
+    if (getFileSize(OTP_PATH)) patchITCM();
 
     //Attempt to read the configuration file
     needConfig = readConfig() ? MODIFY_CONFIGURATION : CREATE_CONFIGURATION;

--- a/arm9/source/memmap.h
+++ b/arm9/source/memmap.h
@@ -1,0 +1,71 @@
+// From: https://github.com/d0k3/GodMode9/blob/master/arm9/source/system/memmap.h
+
+# pragma once
+
+
+// general memory areas
+
+#define __ITCM_ADDR     0x01FF8000
+#define __ITCM_LEN      0x00008000
+
+#define __DTCM_ADDR     0x30008000
+#define __DTCM_LEN      0x00004000
+
+#define __A9RAM0_ADDR   0x08000000
+#define __A9RAM0_LEN    0x00100000
+
+#define __A9RAM1_ADDR   0x08100000
+#define __A9RAM1_LEN    0x00080000
+
+#define __VRAM_ADDR     0x18000000
+#define __VRAM_LEN      0x00600000
+
+#define __DSP_ADDR      0x1FF00000
+#define __DSP_LEN       0x00080000
+
+#define __AWRAM_ADDR    0x1FF80000
+#define __AWRAM_LEN     0x00080000
+
+#define __OTP_ADDR      0x10012000
+#define __OTP_LEN       0x00000100
+
+#define __FCRAM0_ADDR   0x20000000
+#define __FCRAM0_END    0x28000000
+#define __FCRAM0_LEN    (__FCRAM0_END - __FCRAM0_ADDR)
+
+#define __FCRAM1_ADDR   0x28000000
+#define __FCRAM1_END    0x30000000
+#define __FCRAM1_LEN    (__FCRAM1_END - __FCRAM1_ADDR)
+
+
+// offsets provided by SciresM, only available if booted on b9s
+
+#define __BOOT9_ADDR    0x08080000
+#define __BOOT9_LEN     0x00010000
+
+#define __BOOT11_ADDR   0x08090000
+#define __BOOT11_LEN    0x00010000
+
+
+// stuff in FCRAM
+// FCRAM0 0x0000...0x1000 is unused
+// see: https://www.3dbrew.org/wiki/FIRM#FIRM_Launch_Parameters
+
+#define __FIRMRAM_ADDR  (__FCRAM0_ADDR + 0x0001000)
+#define __FIRMRAM_END   (__FIRMRAM_ADDR + 0x0400000)
+
+#define __FIRMTMP_ADDR  (__FCRAM0_END - 0x0800000)
+#define __FIRMTMP_END   (__FIRMTMP_ADDR + 0x0400000)
+
+#define __RAMDRV_ADDR   (__FCRAM0_ADDR + 0x2800000)
+#define __RAMDRV_END    __FCRAM0_END
+#define __RAMDRV_END_N  __FCRAM1_END
+
+#define __STACK_ABT_TOP __RAMDRV_ADDR
+#define __STACK_ABT_LEN 0x10000
+
+#define __STACK_TOP     (__STACK_ABT_TOP - __STACK_ABT_LEN)
+#define __STACK_LEN     0x7F0000 
+
+#define __HEAP_ADDR     (__FCRAM0_ADDR + 0x0001000)
+#define __HEAP_END      (__STACK_TOP - __STACK_LEN)


### PR DESCRIPTION
Is this something that might be worth adding? Or possibly including a config option that enables this mod. I find it to be quite useful and I'm sure other people would as well. Here's a post about it: [https://gbatemp.net/threads/release-luma3ds-mod-to-unban-a-console-with-022-2812.565173/](https://gbatemp.net/threads/release-luma3ds-mod-to-unban-a-console-with-022-2812.565173/).

In summary, it replaces the device's CTCert with the one in the OTP in /luma/otp.bin. If /luma/otp.bin doesn't exist, it doesn't replace anything. It's helpful for spoofing an unbanned CTCert to get around console bans.