### PR TITLE
Fix release building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ boot.firm:	$(SUBFOLDERS)
 	@echo built... $(notdir $@)
 
 boot.3dsx:
-	@curl -sS "https://github.com/fincs/new-hbmenu/releases/download/v2.1.1/boot.3dsx" -o "boot.3dsx"
+	@curl -sS "https://github.com/fincs/new-hbmenu/releases/latest/download/boot.3dsx" -o "boot.3dsx"
 
 $(SUBFOLDERS):
 	@$(MAKE) -C $@ all

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ release:	$(NAME)$(REVISION).zip
 
 clean:
 	@$(foreach dir, $(SUBFOLDERS), $(MAKE) -C $(dir) clean &&) true
-	@rm -rf *.firm *.zip
+	@rm -rf *.firm *.zip *.3dsx
 
 # boot.3dsx comes from https://github.com/fincs/new-hbmenu/releases
 $(NAME)$(REVISION).zip:	boot.firm boot.3dsx
@@ -25,6 +25,9 @@ boot.firm:	$(SUBFOLDERS)
 	@firmtool build $@ -D sysmodules/sysmodules.bin arm11/arm11.elf arm9/arm9.elf k11_extension/k11_extension.elf \
 	-A 0x18180000 -C XDMA XDMA NDMA XDMA
 	@echo built... $(notdir $@)
+
+boot.3dsx:
+	@curl -sS "https://github.com/fincs/new-hbmenu/releases/download/v2.1.1/boot.3dsx" -o "boot.3dsx"
 
 $(SUBFOLDERS):
 	@$(MAKE) -C $@ all

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ boot.firm:	$(SUBFOLDERS)
 	@echo built... $(notdir $@)
 
 boot.3dsx:
-	@curl -sS "https://github.com/fincs/new-hbmenu/releases/latest/download/boot.3dsx" -o "boot.3dsx"
+	@curl -sSL "https://github.com/fincs/new-hbmenu/releases/latest/download/boot.3dsx" -o "boot.3dsx"
 
 $(SUBFOLDERS):
 	@$(MAKE) -C $@ all


### PR DESCRIPTION
`boot.3dsx` is downloaded from a static URL via `curl`.

Still new at this, so tips are welcome.

Fixes #1453