### PR TITLE
fix typo in screen filters menu

### DIFF
--- a/sysmodules/rosalina/source/menus/screen_filters.c
+++ b/sysmodules/rosalina/source/menus/screen_filters.c
@@ -116,7 +116,7 @@ Menu screenFiltersMenu = {
         { "[2700K] Incandescent", METHOD, .method = &ScreenFiltersMenu_SetIncandescent },
         { "[2300K] Warm Incandescent", METHOD, .method = &ScreenFiltersMenu_SetWarmIncandescent },
         { "[1900K] Candle", METHOD, .method = &ScreenFiltersMenu_SetCandle },
-        { "[2700K] Ember", METHOD, .method = &ScreenFiltersMenu_SetEmber },
+        { "[1200K] Ember", METHOD, .method = &ScreenFiltersMenu_SetEmber },
         {},
     }
 };


### PR DESCRIPTION
Ember is 1200K, not 2700K.