### PR TITLE
Patch DLP client region check

### DIFF
--- a/sysmodules/loader/source/patcher.c
+++ b/sysmodules/loader/source/patcher.c
@@ -817,12 +817,27 @@ void patchCode(u64 progId, u16 progVer, u8 *code, u32 size, u32 textSize, u32 ro
             0x00, 0x00, 0x00, 0x00
         };
 
+        static const u8 pattern2[] = {
+            0xBB, 0xD1
+        },
+                        patch2[] = {
+            0xC0, 0x46 // mov r8, r8
+        };
+
         //Patch DLP region check
         if(!patchMemory(code, textSize,
                 pattern,
                 sizeof(pattern), 0,
                 patch,
                 sizeof(patch), 1
+            )) goto error;
+        
+        // Patch DLP client region check
+        if (!patchMemory(code, textSize,
+               pattern2,
+               sizeof(pattern2), 0,
+               patch2,
+               sizeof(patch2), 1
             )) goto error;
     }
 

--- a/sysmodules/loader/source/patcher.c
+++ b/sysmodules/loader/source/patcher.c
@@ -818,7 +818,10 @@ void patchCode(u64 progId, u16 progVer, u8 *code, u32 size, u32 textSize, u32 ro
         };
 
         static const u8 pattern2[] = {
-            0xBB, 0xD1
+            0x20, 0x82, 0xa8, 0x7e, 0x00, 0x28, 0x00, 0xd0, 0x01, 0x20, 0xa0, 0x77
+        },
+                        pattern3[] = {
+            0x42
         },
                         patch2[] = {
             0xC0, 0x46 // mov r8, r8
@@ -833,9 +836,11 @@ void patchCode(u64 progId, u16 progVer, u8 *code, u32 size, u32 textSize, u32 ro
             )) goto error;
         
         // Patch DLP client region check
-        if (!patchMemory(code, textSize,
-               pattern2,
-               sizeof(pattern2), 0,
+        u8 *found = memsearch(code, pattern2, textSize, sizeof(pattern2));
+        
+        if (!patchMemory(found, textSize,
+               pattern3,
+               sizeof(pattern3), 1,
                patch2,
                sizeof(patch2), 1
             )) goto error;


### PR DESCRIPTION
Removes checking whether the system region matches the advertised game region within DLPCLNT:StartScan().
Patches instruction from branching if not equal to doing nothing.
This allows systems from different regions to download play with each other and should resolve #1354.
Tested with a USA N3DS hosting a MarioKart 7 download play session. JP N2DS was able to connect both through the download play application and MarioKart 7.
Feel free to alter style of the changes.