### PR TITLE
Stop final line read from erroneously reporting failure

### DIFF
--- a/sysmodules/rosalina/source/menus/cheats.c
+++ b/sysmodules/rosalina/source/menus/cheats.c
@@ -1645,7 +1645,7 @@ static Result Cheat_ReadLine(BufferedFile* file, char* line, u32 lineSize)
         if (total == 0)
         {
             line[idx] = '\0';
-            return -1;
+            return 0;
         }
         if (R_SUCCEEDED(res))
         {


### PR DESCRIPTION
Should fix issues with cheat files without trailing newlines.