### PR TITLE
rosalina: Add time display in menu

### DIFF
--- a/sysmodules/rosalina/source/menu.c
+++ b/sysmodules/rosalina/source/menu.c
@@ -293,6 +293,17 @@ static void menuDraw(Menu *menu, u32 selected)
         int n = sprintf(ipBuffer, "%hhu.%hhu.%hhu.%hhu", addr[0], addr[1], addr[2], addr[3]);
         Draw_DrawString(SCREEN_BOT_WIDTH - 10 - SPACING_X * n, 10, COLOR_WHITE, ipBuffer);
     }
+    else
+    {
+        char timeString[9];
+        u64 timeInSeconds = osGetTime() / 1000;
+        u64 dayTime = timeInSeconds % 86400;
+        u8 hour = dayTime / 3600;
+        u8 min = (dayTime % 3600) / 60;
+        u8 seconds = dayTime % 60;
+        int n = sprintf(timeString, "%02d:%02d:%02d", hour, min, seconds);
+        Draw_DrawString(SCREEN_BOT_WIDTH - 10 - SPACING_X * n, 10, COLOR_WHITE, timeString);
+    }
 
     Draw_DrawFormattedString(SCREEN_BOT_WIDTH - 10 - 4 * SPACING_X, SCREEN_BOT_HEIGHT - 20, COLOR_WHITE, "    ");
 


### PR DESCRIPTION
Added time display in Rosalina menu when debugger is disabled