### PR TITLE
Fix various things about the cheat system

### DIFF
--- a/sysmodules/rosalina/source/menus/cheats.c
+++ b/sysmodules/rosalina/source/menus/cheats.c
@@ -1318,6 +1318,8 @@ static u32 Cheat_ApplyCheat(const Handle processHandle, CheatDescription* const 
                         {
                             if (cheat_state.floatMode)
                             {
+                                float flarg1;
+                                memcpy(&flarg1, &arg1, sizeof(float));
                                 u32 tmp;
                                 if (!Cheat_Read32(processHandle, arg0 & 0x00FFFFFF, &tmp))
                                 {
@@ -1325,7 +1327,7 @@ static u32 Cheat_ApplyCheat(const Handle processHandle, CheatDescription* const 
                                 }
                                 float value;
                                 memcpy(&value, &tmp, sizeof(float));
-                                value += arg1;
+                                value += flarg1;
                                 memcpy(&tmp, &value, sizeof(u32));
                                 if (!Cheat_Write32(processHandle, arg0 & 0x00FFFFFF, tmp))
                                 {
@@ -1351,6 +1353,8 @@ static u32 Cheat_ApplyCheat(const Handle processHandle, CheatDescription* const 
                         {
                             if (cheat_state.floatMode)
                             {
+                                float flarg1;
+                                memcpy(&flarg1, &arg1, sizeof(float));
                                 u32 tmp;
                                 if (!Cheat_Read32(processHandle, arg0 & 0x00FFFFFF, &tmp))
                                 {
@@ -1358,7 +1362,7 @@ static u32 Cheat_ApplyCheat(const Handle processHandle, CheatDescription* const 
                                 }
                                 float value;
                                 memcpy(&value, &tmp, sizeof(float));
-                                value *= arg1;
+                                value *= flarg1;
                                 memcpy(&tmp, &value, sizeof(u32));
                                 if (!Cheat_Write32(processHandle, arg0 & 0x00FFFFFF, tmp))
                                 {
@@ -1384,6 +1388,8 @@ static u32 Cheat_ApplyCheat(const Handle processHandle, CheatDescription* const 
                         {
                             if (cheat_state.floatMode)
                             {
+                                float flarg1;
+                                memcpy(&flarg1, &arg1, sizeof(float));
                                 u32 tmp;
                                 if (!Cheat_Read32(processHandle, arg0 & 0x00FFFFFF, &tmp))
                                 {
@@ -1391,7 +1397,7 @@ static u32 Cheat_ApplyCheat(const Handle processHandle, CheatDescription* const 
                                 }
                                 float value;
                                 memcpy(&value, &tmp, sizeof(float));
-                                value /= arg1;
+                                value /= flarg1;
                                 memcpy(&tmp, &value, sizeof(u32));
                                 if (!Cheat_Write32(processHandle, arg0 & 0x00FFFFFF, tmp))
                                 {
@@ -1417,9 +1423,11 @@ static u32 Cheat_ApplyCheat(const Handle processHandle, CheatDescription* const 
                         {
                             if (cheat_state.data1Mode)
                             {
+                                float flarg1;
+                                memcpy(&flarg1, &arg1, sizeof(float));
                                 float value;
                                 memcpy(&value, activeData(), sizeof(float));
-                                value *= arg1;
+                                value *= flarg1;
                                 memcpy(activeData(), &value, sizeof(float));
                             }
                             else
@@ -1432,9 +1440,11 @@ static u32 Cheat_ApplyCheat(const Handle processHandle, CheatDescription* const 
                         {
                             if (cheat_state.data1Mode)
                             {
+                                float flarg1;
+                                memcpy(&flarg1, &arg1, sizeof(float));
                                 float value;
                                 memcpy(&value, activeData(), sizeof(float));
-                                value /= arg1;
+                                value /= flarg1;
                                 memcpy(activeData(), &value, sizeof(float));
                             }
                             else

--- a/sysmodules/rosalina/source/menus/cheats.c
+++ b/sysmodules/rosalina/source/menus/cheats.c
@@ -1311,196 +1311,235 @@ static u32 Cheat_ApplyCheat(const Handle processHandle, CheatDescription* const 
                     {
                         case 0x0:
                         {
-                            cheat_state.floatMode = arg1 & 0x1;
+                            if(!skipExecution)
+                            {
+                                cheat_state.floatMode = arg1 & 0x1;
+                            }
                         }
                             break;
                         case 0x1:
                         {
-                            if (cheat_state.floatMode)
+                            if (!skipExecution)
                             {
-                                float flarg1;
-                                memcpy(&flarg1, &arg1, sizeof(float));
-                                u32 tmp;
-                                if (!Cheat_Read32(processHandle, arg0 & 0x00FFFFFF, &tmp))
+                                if (cheat_state.floatMode)
                                 {
-                                    return 0;
+                                    float flarg1;
+                                    memcpy(&flarg1, &arg1, sizeof(float));
+                                    u32 tmp;
+                                    if (!Cheat_Read32(processHandle, arg0 & 0x00FFFFFF, &tmp))
+                                    {
+                                        return 0;
+                                    }
+                                    float value;
+                                    memcpy(&value, &tmp, sizeof(float));
+                                    value += flarg1;
+                                    memcpy(&tmp, &value, sizeof(u32));
+                                    if (!Cheat_Write32(processHandle, arg0 & 0x00FFFFFF, tmp))
+                                    {
+                                        return 0;
+                                    }
                                 }
-                                float value;
-                                memcpy(&value, &tmp, sizeof(float));
-                                value += flarg1;
-                                memcpy(&tmp, &value, sizeof(u32));
-                                if (!Cheat_Write32(processHandle, arg0 & 0x00FFFFFF, tmp))
+                                else
                                 {
-                                    return 0;
-                                }
-                            }
-                            else
-                            {
-                                u32 tmp;
-                                if (!Cheat_Read32(processHandle, arg0 & 0x00FFFFFF, &tmp))
-                                {
-                                    return 0;
-                                }
-                                tmp += arg1;
-                                if (!Cheat_Write32(processHandle, arg0 & 0x00FFFFFF, tmp))
-                                {
-                                    return 0;
+                                    u32 tmp;
+                                    if (!Cheat_Read32(processHandle, arg0 & 0x00FFFFFF, &tmp))
+                                    {
+                                        return 0;
+                                    }
+                                    tmp += arg1;
+                                    if (!Cheat_Write32(processHandle, arg0 & 0x00FFFFFF, tmp))
+                                    {
+                                        return 0;
+                                    }
                                 }
                             }
                         }
                             break;
                         case 0x2:
                         {
-                            if (cheat_state.floatMode)
+                            if (!skipExecution)
                             {
-                                float flarg1;
-                                memcpy(&flarg1, &arg1, sizeof(float));
-                                u32 tmp;
-                                if (!Cheat_Read32(processHandle, arg0 & 0x00FFFFFF, &tmp))
+                                if (cheat_state.floatMode)
                                 {
-                                    return 0;
+                                    float flarg1;
+                                    memcpy(&flarg1, &arg1, sizeof(float));
+                                    u32 tmp;
+                                    if (!Cheat_Read32(processHandle, arg0 & 0x00FFFFFF, &tmp))
+                                    {
+                                        return 0;
+                                    }
+                                    float value;
+                                    memcpy(&value, &tmp, sizeof(float));
+                                    value *= flarg1;
+                                    memcpy(&tmp, &value, sizeof(u32));
+                                    if (!Cheat_Write32(processHandle, arg0 & 0x00FFFFFF, tmp))
+                                    {
+                                        return 0;
+                                    }
                                 }
-                                float value;
-                                memcpy(&value, &tmp, sizeof(float));
-                                value *= flarg1;
-                                memcpy(&tmp, &value, sizeof(u32));
-                                if (!Cheat_Write32(processHandle, arg0 & 0x00FFFFFF, tmp))
+                                else
                                 {
-                                    return 0;
-                                }
-                            }
-                            else
-                            {
-                                u32 tmp;
-                                if (!Cheat_Read32(processHandle, arg0 & 0x00FFFFFF, &tmp))
-                                {
-                                    return 0;
-                                }
-                                tmp *= arg1;
-                                if (!Cheat_Write32(processHandle, arg0 & 0x00FFFFFF, tmp))
-                                {
-                                    return 0;
+                                    u32 tmp;
+                                    if (!Cheat_Read32(processHandle, arg0 & 0x00FFFFFF, &tmp))
+                                    {
+                                        return 0;
+                                    }
+                                    tmp *= arg1;
+                                    if (!Cheat_Write32(processHandle, arg0 & 0x00FFFFFF, tmp))
+                                    {
+                                        return 0;
+                                    }
                                 }
                             }
                         }
                             break;
                         case 0x3:
                         {
-                            if (cheat_state.floatMode)
+                            if (!skipExecution)
                             {
-                                float flarg1;
-                                memcpy(&flarg1, &arg1, sizeof(float));
-                                u32 tmp;
-                                if (!Cheat_Read32(processHandle, arg0 & 0x00FFFFFF, &tmp))
+                                if (cheat_state.floatMode)
                                 {
-                                    return 0;
+                                    float flarg1;
+                                    memcpy(&flarg1, &arg1, sizeof(float));
+                                    u32 tmp;
+                                    if (!Cheat_Read32(processHandle, arg0 & 0x00FFFFFF, &tmp))
+                                    {
+                                        return 0;
+                                    }
+                                    float value;
+                                    memcpy(&value, &tmp, sizeof(float));
+                                    value /= flarg1;
+                                    memcpy(&tmp, &value, sizeof(u32));
+                                    if (!Cheat_Write32(processHandle, arg0 & 0x00FFFFFF, tmp))
+                                    {
+                                        return 0;
+                                    }
                                 }
-                                float value;
-                                memcpy(&value, &tmp, sizeof(float));
-                                value /= flarg1;
-                                memcpy(&tmp, &value, sizeof(u32));
-                                if (!Cheat_Write32(processHandle, arg0 & 0x00FFFFFF, tmp))
+                                else
                                 {
-                                    return 0;
-                                }
-                            }
-                            else
-                            {
-                                u32 tmp;
-                                if (!Cheat_Read32(processHandle, arg0 & 0x00FFFFFF, &tmp))
-                                {
-                                    return 0;
-                                }
-                                tmp /= arg1;
-                                if (!Cheat_Write32(processHandle, arg0 & 0x00FFFFFF, tmp))
-                                {
-                                    return 0;
+                                    u32 tmp;
+                                    if (!Cheat_Read32(processHandle, arg0 & 0x00FFFFFF, &tmp))
+                                    {
+                                        return 0;
+                                    }
+                                    tmp /= arg1;
+                                    if (!Cheat_Write32(processHandle, arg0 & 0x00FFFFFF, tmp))
+                                    {
+                                        return 0;
+                                    }
                                 }
                             }
                         }
                             break;
                         case 0x4:
                         {
-                            if (cheat_state.data1Mode)
+                            if (!skipExecution)
                             {
-                                float flarg1;
-                                memcpy(&flarg1, &arg1, sizeof(float));
-                                float value;
-                                memcpy(&value, activeData(), sizeof(float));
-                                value *= flarg1;
-                                memcpy(activeData(), &value, sizeof(float));
-                            }
-                            else
-                            {
-                                *activeData() *= arg1;
+                                if (cheat_state.data1Mode)
+                                {
+                                    float flarg1;
+                                    memcpy(&flarg1, &arg1, sizeof(float));
+                                    float value;
+                                    memcpy(&value, activeData(), sizeof(float));
+                                    value *= flarg1;
+                                    memcpy(activeData(), &value, sizeof(float));
+                                }
+                                else
+                                {
+                                    *activeData() *= arg1;
+                                }
                             }
                         }
                             break;
                         case 0x5:
                         {
-                            if (cheat_state.data1Mode)
+                            if (!skipExecution)
                             {
-                                float flarg1;
-                                memcpy(&flarg1, &arg1, sizeof(float));
-                                float value;
-                                memcpy(&value, activeData(), sizeof(float));
-                                value /= flarg1;
-                                memcpy(activeData(), &value, sizeof(float));
-                            }
-                            else
-                            {
-                                *activeData() /= arg1;
+                                if (cheat_state.data1Mode)
+                                {
+                                    float flarg1;
+                                    memcpy(&flarg1, &arg1, sizeof(float));
+                                    float value;
+                                    memcpy(&value, activeData(), sizeof(float));
+                                    value /= flarg1;
+                                    memcpy(activeData(), &value, sizeof(float));
+                                }
+                                else
+                                {
+                                    *activeData() /= arg1;
+                                }
                             }
                         }
                             break;
                         case 0x6:
                         {
-                            *activeData() &= arg1;
+                            if (!skipExecution)
+                            {
+                                *activeData() &= arg1;
+                            }
                         }
                             break;
                         case 0x7:
                         {
-                            *activeData() |= arg1;
+                            if (!skipExecution)
+                            {
+                                *activeData() |= arg1;
+                            }
                         }
                             break;
                         case 0x8:
                         {
-                            *activeData() ^= arg1;
+                            if (!skipExecution)
+                            {
+                                *activeData() ^= arg1;
+                            }
                         }
                             break;
                         case 0x9:
                         {
-                            *activeData() = ~*activeData();
+                            if (!skipExecution)
+                            {
+                                *activeData() = ~*activeData();
+                            }
                         }
                             break;
                         case 0xA:
                         {
-                            *activeData() <<= arg1;
+                            if (!skipExecution)
+                            {
+                                *activeData() <<= arg1;
+                            }
                         }
                             break;
                         case 0xB:
                         {
-                            *activeData() >>= arg1;
+                            if (!skipExecution)
+                            {
+                                *activeData() >>= arg1;
+                            }
                         }
                             break;
                         case 0xC:
                         {
-                            u8 origActiveOffset = cheat_state.activeOffset;
-                            for (size_t i = 0; i < arg1; i++)
+                            if (!skipExecution)
                             {
-                                u8 data;
-                                cheat_state.activeOffset = 1;
-                                if (!Cheat_Read8(processHandle, 0, &data))
+                                u8 origActiveOffset = cheat_state.activeOffset;
+                                for (size_t i = 0; i < arg1; i++)
                                 {
-                                    return 0;
+                                    u8 data;
+                                    cheat_state.activeOffset = 1;
+                                    if (!Cheat_Read8(processHandle, 0, &data))
+                                    {
+                                        return 0;
+                                    }
+                                    cheat_state.activeOffset = 0;
+                                    if (!Cheat_Write8(processHandle, 0, data))
+                                    {
+                                        return 0;
+                                    }
                                 }
-                                cheat_state.activeOffset = 0;
-                                if (!Cheat_Write8(processHandle, 0, data))
-                                {
-                                    return 0;
-                                }
+                                cheat_state.activeOffset = origActiveOffset;
                             }
-                            cheat_state.activeOffset = origActiveOffset;
                         }
                             break;
                         // Search for pattern
@@ -1553,9 +1592,12 @@ static u32 Cheat_ApplyCheat(const Handle processHandle, CheatDescription* const 
                             break;
                         case 0xF:
                         {
-                            u32 range = arg1 - (arg0 & 0xFFFFFF);
-                            u32 number = Cheat_GetRandomNumber() % range;
-                            *activeData() = (arg0 & 0xFFFFFF) + number;
+                            if (!skipExecution)
+                            {
+                                u32 range = arg1 - (arg0 & 0xFFFFFF);
+                                u32 number = Cheat_GetRandomNumber() % range;
+                                *activeData() = (arg0 & 0xFFFFFF) + number;
+                            }
                         }
                             break;
                         default:

--- a/sysmodules/rosalina/source/menus/cheats.c
+++ b/sysmodules/rosalina/source/menus/cheats.c
@@ -322,18 +322,32 @@ static u32 Cheat_ApplyCheat(const Handle processHandle, CheatDescription* const 
                 // Simple: If the value at address 0XXXXXXX is less than the value YYYYYYYY.
                 // Example: 323D6B28 10000000
             {
+                bool newSkip;
                 u32 value = 0;
-                if (!Cheat_Read32(processHandle, arg0 & 0x0FFFFFFF, &value)) return 0;
-
+                switch (cheat_state.conditionalMode)
+                {
+                    case 0x0:
+                        if (!Cheat_Read32(processHandle, arg0 & 0x0FFFFFFF, &value)) return 0;
+                        newSkip = !(value < arg1);
+                        break;
+                    case 0x1:
+                        if (!Cheat_Read32(processHandle, arg0 & 0x0FFFFFFF, &value)) return 0;
+                        newSkip = !(value < *activeData());
+                        break;
+                    case 0x2:
+                        newSkip = !(*activeData() < arg1);
+                        break;
+                    case 0x3:
+                        newSkip = !(*activeStorage(cheat) < arg1);
+                        break;
+                    case 0x4:
+                        newSkip = !(*activeData() < *activeStorage(cheat));
+                        break;
+                    default:
+                        return 0;
+                }
                 cheat_state.ifStack <<= 1;
-                if (value < arg1)
-                {
-                    cheat_state.ifStack |= skipExecution ? 1 : 0;
-                }
-                else
-                {
-                    cheat_state.ifStack |= 1;
-                }
+                cheat_state.ifStack |= (newSkip || skipExecution) ? 1 : 0;
                 cheat_state.ifCount++;
             }
                 break;
@@ -344,18 +358,32 @@ static u32 Cheat_ApplyCheat(const Handle processHandle, CheatDescription* const 
                 // Simple: If the value at address 0XXXXXXX is greater than the value YYYYYYYY.
                 // Example: 423D6B28 10000000
             {
+                bool newSkip;
                 u32 value = 0;
-                if (!Cheat_Read32(processHandle, arg0 & 0x0FFFFFFF, &value)) return 0;
-                
+                switch (cheat_state.conditionalMode)
+                {
+                    case 0x0:
+                        if (!Cheat_Read32(processHandle, arg0 & 0x0FFFFFFF, &value)) return 0;
+                        newSkip = !(value > arg1);
+                        break;
+                    case 0x1:
+                        if (!Cheat_Read32(processHandle, arg0 & 0x0FFFFFFF, &value)) return 0;
+                        newSkip = !(value > *activeData());
+                        break;
+                    case 0x2:
+                        newSkip = !(*activeData() > arg1);
+                        break;
+                    case 0x3:
+                        newSkip = !(*activeStorage(cheat) > arg1);
+                        break;
+                    case 0x4:
+                        newSkip = !(*activeData() > *activeStorage(cheat));
+                        break;
+                    default:
+                        return 0;
+                }
                 cheat_state.ifStack <<= 1;
-                if (value > arg1)
-                {
-                    cheat_state.ifStack |= skipExecution ? 1 : 0;
-                }
-                else
-                {
-                    cheat_state.ifStack |= 1;
-                }
+                cheat_state.ifStack |= (newSkip || skipExecution) ? 1 : 0;
                 cheat_state.ifCount++;
             }
                 break;
@@ -366,18 +394,32 @@ static u32 Cheat_ApplyCheat(const Handle processHandle, CheatDescription* const 
                 // Simple: If the value at address 0XXXXXXX is equal to the value YYYYYYYY.
                 // Example: 523D6B28 10000000
             {
+                bool newSkip;
                 u32 value = 0;
-                if (!Cheat_Read32(processHandle, arg0 & 0x0FFFFFFF, &value)) return 0;
-
+                switch (cheat_state.conditionalMode)
+                {
+                    case 0x0:
+                        if (!Cheat_Read32(processHandle, arg0 & 0x0FFFFFFF, &value)) return 0;
+                        newSkip = !(value == arg1);
+                        break;
+                    case 0x1:
+                        if (!Cheat_Read32(processHandle, arg0 & 0x0FFFFFFF, &value)) return 0;
+                        newSkip = !(value == *activeData());
+                        break;
+                    case 0x2:
+                        newSkip = !(*activeData() == arg1);
+                        break;
+                    case 0x3:
+                        newSkip = !(*activeStorage(cheat) == arg1);
+                        break;
+                    case 0x4:
+                        newSkip = !(*activeData() == *activeStorage(cheat));
+                        break;
+                    default:
+                        return 0;
+                }
                 cheat_state.ifStack <<= 1;
-                if (value == arg1)
-                {
-                    cheat_state.ifStack |= skipExecution ? 1 : 0;
-                }
-                else
-                {
-                    cheat_state.ifStack |= 1;
-                }
+                cheat_state.ifStack |= (newSkip || skipExecution) ? 1 : 0;
                 cheat_state.ifCount++;
             }
                 break;
@@ -388,18 +430,32 @@ static u32 Cheat_ApplyCheat(const Handle processHandle, CheatDescription* const 
                 // Simple: If the value at address 0XXXXXXX is not equal to the value YYYYYYYY.
                 // Example: 623D6B28 10000000
             {
+                bool newSkip;
                 u32 value = 0;
-                if (!Cheat_Read32(processHandle, arg0 & 0x0FFFFFFF, &value)) return 0;
-
+                switch (cheat_state.conditionalMode)
+                {
+                    case 0x0:
+                        if (!Cheat_Read32(processHandle, arg0 & 0x0FFFFFFF, &value)) return 0;
+                        newSkip = !(value != arg1);
+                        break;
+                    case 0x1:
+                        if (!Cheat_Read32(processHandle, arg0 & 0x0FFFFFFF, &value)) return 0;
+                        newSkip = !(value != *activeData());
+                        break;
+                    case 0x2:
+                        newSkip = !(*activeData() != arg1);
+                        break;
+                    case 0x3:
+                        newSkip = !(*activeStorage(cheat) != arg1);
+                        break;
+                    case 0x4:
+                        newSkip = !(*activeData() != *activeStorage(cheat));
+                        break;
+                    default:
+                        return 0;
+                }
                 cheat_state.ifStack <<= 1;
-                if (value != arg1)
-                {
-                    cheat_state.ifStack |= skipExecution ? 1 : 0;
-                }
-                else
-                {
-                    cheat_state.ifStack |= 1;
-                }
+                cheat_state.ifStack |= (newSkip || skipExecution) ? 1 : 0;
                 cheat_state.ifCount++;
             }
                 break;
@@ -413,13 +469,14 @@ static u32 Cheat_ApplyCheat(const Handle processHandle, CheatDescription* const 
                 bool newSkip;
                 u16 mask = (u16) ((arg1 >> 16) & 0xFFFF);
                 u16 value = 0;
-                if (!Cheat_Read16(processHandle, arg0 & 0x0FFFFFFF, &value)) return 0;
                 switch (cheat_state.conditionalMode)
                 {
                     case 0x0:
+                        if (!Cheat_Read16(processHandle, arg0 & 0x0FFFFFFF, &value)) return 0;
                         newSkip = !((value & (~mask)) < (arg1 & 0xFFFF));
                         break;
                     case 0x1:
+                        if (!Cheat_Read16(processHandle, arg0 & 0x0FFFFFFF, &value)) return 0;
                         newSkip = !((value & (~mask)) < (*activeData() & (~mask)));
                         break;
                     case 0x2:
@@ -449,13 +506,14 @@ static u32 Cheat_ApplyCheat(const Handle processHandle, CheatDescription* const 
                 bool newSkip;
                 u16 mask = (u16) ((arg1 >> 16) & 0xFFFF);
                 u16 value = 0;
-                if (!Cheat_Read16(processHandle, arg0 & 0x0FFFFFFF, &value)) return 0;
                 switch (cheat_state.conditionalMode)
                 {
                     case 0x0:
+                        if (!Cheat_Read16(processHandle, arg0 & 0x0FFFFFFF, &value)) return 0;
                         newSkip = !((value & (~mask)) > (arg1 & 0xFFFF));
                         break;
                     case 0x1:
+                        if (!Cheat_Read16(processHandle, arg0 & 0x0FFFFFFF, &value)) return 0;
                         newSkip = !((value & (~mask)) > (*activeData() & (~mask)));
                         break;
                     case 0x2:
@@ -486,13 +544,14 @@ static u32 Cheat_ApplyCheat(const Handle processHandle, CheatDescription* const 
                 bool newSkip;
                 u16 mask = (u16) ((arg1 >> 16) & 0xFFFF);
                 u16 value = 0;
-                if (!Cheat_Read16(processHandle, arg0 & 0x0FFFFFFF, &value)) return 0;
                 switch (cheat_state.conditionalMode)
                 {
                     case 0x0:
+                        if (!Cheat_Read16(processHandle, arg0 & 0x0FFFFFFF, &value)) return 0;
                         newSkip = !((value & (~mask)) == (arg1 & 0xFFFF));
                         break;
                     case 0x1:
+                        if (!Cheat_Read16(processHandle, arg0 & 0x0FFFFFFF, &value)) return 0;
                         newSkip = !((value & (~mask)) == (*activeData() & (~mask)));
                         break;
                     case 0x2:
@@ -523,13 +582,14 @@ static u32 Cheat_ApplyCheat(const Handle processHandle, CheatDescription* const 
                 bool newSkip;
                 u16 mask = (u16) ((arg1 >> 16) & 0xFFFF);
                 u16 value = 0;
-                if (!Cheat_Read16(processHandle, arg0 & 0x0FFFFFFF, &value)) return 0;
                 switch (cheat_state.conditionalMode)
                 {
                     case 0x0:
+                        if (!Cheat_Read16(processHandle, arg0 & 0x0FFFFFFF, &value)) return 0;
                         newSkip = !((value & (~mask)) != (arg1 & 0xFFFF));
                         break;
                     case 0x1:
+                        if (!Cheat_Read16(processHandle, arg0 & 0x0FFFFFFF, &value)) return 0;
                         newSkip = !((value & (~mask)) != (*activeData() & (~mask)));
                         break;
                     case 0x2:


### PR DESCRIPTION
Fixes #1621.

Also fixes some other various issues which I noticed while browsing the source code:
- shouldExecute not checked for math operations
- immediate values not treated as floats for math operations

<hr>

I still can't figure out why a cheat like
```
DD000000 00000400     ; If X is pressed
  D3000000 098F722C   ;   set offset to the move speed address
  DFFFFFFF 00000003   ;   compare storage with immediate
  60000000 00000000   ;   if storage is +0.0
    DF000002 00010000 ;     copy storage to data
    D6000000 00000000 ;     store data at move speed
  D0000000 00000000   ;
  F0000001 00000001   ;   set multiply to float mode
  F2000000 3F8147AE   ;   multiply move speed by 1.01
  D9000000 00000000   ;   load move speed into data
  DF000002 00020000   ;   copy data to storage
D2000000 00000000
```
writes the incorrect values to the movement speed, as compared to
```
DD000000 00000400     ; If X is pressed
  D3000000 098F722C   ;   set offset to the move speed address
  F0000001 00000001   ;   set multiply to float mode
  F2000000 3F8147AE   ;   multiply move speed by 1.01
D2000000 00000000
```
which has the intended behavior.

Both of these cheat codes are for Ocarina of Time 3D. The former can be tested by just moving and holding X, for the latter you must find some way of moving during ESS (crouch-stab ESS is the easiest) and then hold X.

I checked all the documentation I could find on Gateshark codes and it seemed to match what I've seen in the Luma source code, so there's some bug here that's beyond my ability to read C code.