### PR TITLE
Allow Patches in the Home Menu

### DIFF
--- a/sysmodules/loader/source/patcher.c
+++ b/sysmodules/loader/source/patcher.c
@@ -548,12 +548,14 @@ static inline bool patchLayeredFs(u64 progId, u8 *code, u32 size, u32 textSize, 
 
 void patchCode(u64 progId, u16 progVer, u8 *code, u32 size, u32 textSize, u32 roSize, u32 dataSize, u32 roAddress, u32 dataAddress)
 {
-    if(progId == 0x0004003000008F02LL || //USA Home Menu
-       progId == 0x0004003000008202LL || //JPN Home Menu
-       progId == 0x0004003000009802LL || //EUR Home Menu
-       progId == 0x000400300000A902LL || //KOR Home Menu
-       progId == 0x000400300000A102LL || //CHN Home Menu
-       progId == 0x000400300000B102LL) //TWN Home Menu
+    bool isHomeMenu = progId == 0x0004003000008F02LL || //USA Home Menu
+                      progId == 0x0004003000008202LL || //JPN Home Menu
+                      progId == 0x0004003000009802LL || //EUR Home Menu
+                      progId == 0x000400300000A902LL || //KOR Home Menu
+                      progId == 0x000400300000A102LL || //CHN Home Menu
+                      progId == 0x000400300000B102LL;   //TWN Home Menu
+
+    if(isHomeMenu)
     {
         bool applyRegionFreePatch = true;
 
@@ -864,7 +866,7 @@ void patchCode(u64 progId, u16 progVer, u8 *code, u32 size, u32 textSize, u32 ro
         if(!patcherApplyCodeBpsPatch(progId, code, size)) goto error;
         if(!applyCodeIpsPatch(progId, code, size)) goto error;
 
-        if((u32)((progId >> 0x20) & 0xFFFFFFEDULL) == 0x00040000)
+        if((u32)((progId >> 0x20) & 0xFFFFFFEDULL) == 0x00040000 || isHomeMenu)
         {
             u8 mask,
                regionId,


### PR DESCRIPTION
Even if patches fail on applets (according to bc6d999), patching seems to work fine on the Home Menu. This PR whitelists game patching in the home menu.

I have tested this change with LayeredFS patches on a USA New 3DS XL and a USA Old 2DS, and both devices worked fine. 

To test, I have patched the applet icons to be blue, changed text (For example "Test Patch" in the below screenshot), and changed the date format string by following a [Home Menu Customization Guide](https://axities.github.io/), but instead of compressing back to a CIA, I compressed the patched files and applied them as a LayeredFS patch.

<p align="center">
<img src="https://user-images.githubusercontent.com/7717888/120857289-9c900980-c546-11eb-8f4c-2cb1c39a706c.png"><br>
<img src="https://user-images.githubusercontent.com/7717888/120857294-9e59cd00-c546-11eb-850e-49f678e05a08.png">
</p>

TODO:
- [ ] Test against other regions
  - Should still work fine, but good to be sure since these have different title IDs.
- [ ] Test that system updates work while home menu is patched.
  - Someone who knows more about the system update process could probably give some insight here. Since patches are fully in memory then I would hope updates still work.