### PR TITLE
rosalina: fix temperature display

### DIFF
--- a/sysmodules/rosalina/source/menu.c
+++ b/sysmodules/rosalina/source/menu.c
@@ -344,7 +344,7 @@ static void menuDraw(Menu *menu, u32 selected)
 
         char buf[32];
         int n = sprintf(
-            buf, "%02hhu\xF8""C  %lu.%02luV  %lu.%lu%%", batteryTemperature, // CP437
+            buf, "   %02hhu\xF8""C  %lu.%02luV  %lu.%lu%%", batteryTemperature, // CP437
             voltageInt, voltageFrac,
             percentageInt, percentageFrac
         );


### PR DESCRIPTION
Added 3 leading spaces to the temperature display format string, so the screen is properly cleared if the amount of characters displayed change.