### PR TITLE
Fix Reading EmuNAND Sector 0

### DIFF
--- a/arm9/source/crypto.c
+++ b/arm9/source/crypto.c
@@ -348,7 +348,7 @@ int ctrNandInit(void)
     u8 __attribute__((aligned(4))) temp[0x200];
 
     //Read NCSD header
-    result = firmSource == FIRMWARE_SYSNAND ? sdmmc_nand_readsectors(0, 1, temp) : sdmmc_sdcard_readsectors(emuHeader, 1, temp);
+    result = firmSource == FIRMWARE_SYSNAND ? sdmmc_nand_readsectors(0, 1, temp) : sdmmc_sdcard_readsectors(emuOffset + emuHeader, 1, temp);
 
     if(!result)
     {

--- a/arm9/source/emunand.c
+++ b/arm9/source/emunand.c
@@ -77,7 +77,7 @@ void locateEmuNand(FirmwareSource *nandType)
             if(!sdmmc_sdcard_readsectors(nandOffset + 1, 1, temp) && memcmp(temp + 0x100, "NCSD", 4) == 0)
             {
                 emuOffset = nandOffset + 1;
-                emuHeader = nandOffset + 1;
+                emuHeader = 0;
                 return;
             }
 
@@ -85,7 +85,7 @@ void locateEmuNand(FirmwareSource *nandType)
             else if(i != 2 && !sdmmc_sdcard_readsectors(nandOffset + nandSize, 1, temp) && memcmp(temp + 0x100, "NCSD", 4) == 0)
             {
                 emuOffset = nandOffset;
-                emuHeader = nandOffset + nandSize;
+                emuHeader = nandSize;
                 return;
             }
         }


### PR DESCRIPTION
This fixes a logic bug that would cause reads to sector 0 of any RedNAND or any Gateway-style EmuNAND that is not the first EmuNAND on the SD to be redirected to the wrong SD sector. As far as I can tell, this bug was introduced in commit 475ddf8 (almost 6 years ago) and has been a thing ever since. It hasn't caused any issues with most use cases of RedNAND because under normal circumstances, the arm9 bootrom loads the system's NAND header from sector 0 of SysNAND into ITCM, then process9 checks for it there and uses that copy if it finds it instead of loading it from NAND again. This bug would only cause functional issues when trying to boot a RedNAND when the system booted from non-NAND (ntrboot), which causes the bootrom to skip over any NAND interactions and not load the header to ITCM, so trying to boot a RedNAND will load the wrong sector as the NAND header, leading to an svcBreak in process9.

I tested this myself with a single RedNAND, multiple RedNANDs, and multiple GW EmuNANDs. [Here](https://cdn.discordapp.com/attachments/441119928334942218/900795217857368074/lumaemufix.firm)'s a build of commit 56e44a6 for anyone who would like to do additional testing.