### PR TITLE
Wait for B release before exiting rosalina menu

### DIFF
--- a/sysmodules/rosalina/source/menu.c
+++ b/sysmodules/rosalina/source/menu.c
@@ -436,8 +436,10 @@ void menuShow(Menu *root)
                 currentMenu = previousMenus[--nbPreviousMenus];
                 selectedItem = previousSelectedItems[nbPreviousMenus];
             }
-            else
+            else {
+                while(scanHeldKeys() & KEY_B);
                 break;
+            }
         }
         else if(pressed & KEY_DOWN)
         {


### PR DESCRIPTION
This simply makes it wait until <kbd>B</kbd> is released before exiting the rosalina menu so that games don't see the <kbd>B</kbd> press. Partial fix to #1660, however it doesn't solve games seeing input on opening the menu so I wouldn't close that.

It's kinda buggy right now and will usually close within a few seconds if you keep holding <kbd>B</kbd>, not sure exactly why but I'm guessing it's probably because it's constantly reading the key state. I'm not very familiar with sysmodule coding so I'm not sure how to make it wait for a frame or so between checks though. 😅 It seems pretty stable if you just tap <kbd>B</kbd> at least.