### PR TITLE
Add ASCII View to Rosalina Process List

### DIFF
--- a/sysmodules/rosalina/source/menus/process_list.c
+++ b/sysmodules/rosalina/source/menus/process_list.c
@@ -386,9 +386,7 @@ static void ProcessListMenu_MemoryViewer(const ProcessInfo *info)
             // ------------------------------------------
             char u8ToChar(u8 val) {
                 if(val < 32 || val > 126)
-                {
                     return '-';
-                }
                 return val;
             }
 

--- a/sysmodules/rosalina/source/menus/process_list.c
+++ b/sysmodules/rosalina/source/menus/process_list.c
@@ -419,15 +419,19 @@ static void ProcessListMenu_MemoryViewer(const ProcessInfo *info)
                 // ------------------------------------------
 
                 // Location
+                const u32 infoY = instructionsY + SPACING_Y;
+                viewerY += SPACING_Y;
                 if(codeAvailable && heapAvailable)
-                {
-                    const u32 infoY = instructionsY + SPACING_Y;
-                    viewerY += SPACING_Y;
+                {    
                     Draw_DrawString(10, infoY, COLOR_WHITE, "Press L or R to switch between heap and code.");
                     if((u32)menus[MENU_MODE_NORMAL].buf == heapDestAddress)
                         Draw_DrawString(10 + SPACING_X * 31, infoY, COLOR_GREEN, "heap");
                     if((u32)menus[MENU_MODE_NORMAL].buf == codeDestAddress)
                         Draw_DrawString(10 + SPACING_X * 40, infoY, COLOR_GREEN, "code");
+                } else {
+                    Draw_DrawString(10, infoY, COLOR_WHITE, "SELECT to dump memory, START to toggle ASCII view.");
+                    if (ascii)
+                        Draw_DrawString(10 + SPACING_X * 39, infoY, COLOR_GREEN, "ASCII");
                 }
                 // ------------------------------------------
 

--- a/sysmodules/rosalina/source/menus/process_list.c
+++ b/sysmodules/rosalina/source/menus/process_list.c
@@ -428,9 +428,11 @@ static void ProcessListMenu_MemoryViewer(const ProcessInfo *info)
                         Draw_DrawString(10 + SPACING_X * 31, infoY, COLOR_GREEN, "heap");
                     if((u32)menus[MENU_MODE_NORMAL].buf == codeDestAddress)
                         Draw_DrawString(10 + SPACING_X * 40, infoY, COLOR_GREEN, "code");
-                } else {
+                }
+                else
+                {
                     Draw_DrawString(10, infoY, COLOR_WHITE, "SELECT to dump memory, START to toggle ASCII view.");
-                    if (ascii)
+                    if(ascii)
                         Draw_DrawString(10 + SPACING_X * 39, infoY, COLOR_GREEN, "ASCII");
                 }
                 // ------------------------------------------


### PR DESCRIPTION
This PR adds the ability to view the memory of a process interpreted as ASCII characters. I've also added some new info text, that appears in place of the switch-between-heap-and-code text when only only one of the heap or text is available, originally I wanted to have it always be shown, but I felt like that might take too much space away from viewing the memory itself. This coincidentally also solves the problem of the memory dump not filling the screen when only one of the heap or code is present.

![](https://user-images.githubusercontent.com/33588728/147785610-6d1291f5-cf3a-4f1c-81d1-e3dff0653ea3.png)

Here we're viewing the memory of the SSL process and can see the text "Nintendo of America Inc." among others

![](https://user-images.githubusercontent.com/33588728/147786086-ea64607c-a7c1-4dc0-956d-b4d1fd26cd9f.png)

Here's what the new info text looks like

(Sorry for the pictures I don't know how to screenshot Rosalina)