### PR TITLE
Rosalina: Fix crash for external PMDBG_DebugNextApplicationByForce

### DIFF
--- a/sysmodules/rosalina/source/menus/debugger.c
+++ b/sysmodules/rosalina/source/menus/debugger.c
@@ -72,6 +72,8 @@ MyThread *debuggerCreateDebugThread(void)
 void debuggerFetchAndSetNextApplicationDebugHandleTask(void *argdata)
 {
     (void)argdata;
+    if(!nextApplicationGdbCtx)
+        return;
     Handle debug = 0;
     PMDBG_RunQueuedProcess(&debug);
     GDB_LockAllContexts(&gdbServer);


### PR DESCRIPTION
Currently Rosalina crashes if `PMDBG_DebugNextApplicationByForce(true)` is called by a different process.

This is caused by Rosalina always assuming itself initiated that call and thus doesn't check if `nextApplicationGdbCtx` was set during notification 0x1000.

This fix allows any process to use `PMDBG_DebugNextApplicationByForce(true)` and listen to that notification without Rosalina interfering or crashing.