### PR TITLE
Allow the user to opt out of copying boot.firm to CTRNAND

### DIFF
--- a/arm9/source/fs.c
+++ b/arm9/source/fs.c
@@ -75,6 +75,11 @@ bool mountFs(bool isSd, bool switchToCtrNand)
     }
 }
 
+bool fileExists(const char *path)
+{
+    return f_stat(path, NULL) == FR_OK;
+}
+
 u32 fileRead(void *dest, const char *path, u32 maxSize)
 {
     FIL file;
@@ -460,7 +465,7 @@ bool doLumaUpgradeProcess(void)
         return false;
 
     // Try to boot.firm to CTRNAND, when applicable
-    if (isSdMode)
+    if (isSdMode && !fileExists("0:/boot.firm.nocopy"))
         ok = fileCopy("0:/boot.firm", "1:/boot.firm", true, fileCopyBuffer, sizeof(fileCopyBuffer));
 
     // Try to backup essential files

--- a/arm9/source/fs.h
+++ b/arm9/source/fs.h
@@ -31,6 +31,7 @@
 #define PATTERN(a) a "_*.firm"
 
 bool mountFs(bool isSd, bool switchToCtrNand);
+bool fileExists(const char *path);
 u32 fileRead(void *dest, const char *path, u32 maxSize);
 u32 getFileSize(const char *path);
 bool fileWrite(const void *buffer, const char *path, u32 size);


### PR DESCRIPTION
This offers power users a way to easily opt out of CTRNAND boot.firm copies in a way that should not easily allow for user error. To prevent boot.firm from being copied to CTRNAND, simply create a file named "boot.firm.nocopy" on the root of the SD card.

There are a few advantages to this approach:
- Unlike with a config.ini option, the user's choice should not be affected by updating Luma3DS.
- The user must intentionally opt out of copying boot.firm to CTRNAND; it's not as simple as pressing the wrong button in a menu.
- Users will not need to delete any file(s) from CTRNAND to undo the boot.firm copy.
- Depending on how this change is documented, its visibility can be obvious enough for technically-minded users to be aware of it, and for "noobs" to not even know that the option exists.
- The noob-friendly feature of copying boot.firm to CTRNAND will remain enabled by default.