### PR TITLE
Fix FSPXI:ReadFileSHA256 error when reading exactly one block from NoCrypto gamecard NCCH ExeFS files

### DIFF
--- a/arm9/linker.ld
+++ b/arm9/linker.ld
@@ -46,6 +46,7 @@ SECTIONS
         chainloader.o(.text*)
         i2c.o(.text*)
         arm9_exception_handlers.o(.text*)
+        *(.large_patch.readFileSHA256Vtab11)
         KEEP (*(.emunand_patch))
 
         *(.arm9_exception_handlers.rodata*)

--- a/arm9/source/firm.c
+++ b/arm9/source/firm.c
@@ -587,6 +587,9 @@ u32 patchNativeFirm(u32 firmVersion, FirmwareSource nandType, bool loadFromStora
 
     ret += patchP9AccessChecks(process9Offset, process9Size);
 
+    //Patch stubbed vtable function 11 of an FSPXI:ReadFileSHA256 auxiliary object
+    ret += patchReadFileSHA256Vtab11(process9Offset, process9Size, process9MemAddr);
+
     mergeSection0(NATIVE_FIRM, firmVersion, loadFromStorage);
     firm->section[0].size = 0;
 

--- a/arm9/source/large_patches.h
+++ b/arm9/source/large_patches.h
@@ -36,3 +36,7 @@ extern const u8 rebootPatch[];
 extern const u32 rebootPatchSize;
 extern u32 rebootPatchFopenPtr;
 extern u16 rebootPatchFileName[80+1];
+
+extern const u8 readFileSHA256Vtab11Patch[];
+extern const u32 readFileSHA256Vtab11PatchSize;
+extern u32 readFileSHA256Vtab11PatchCtorPtr, readFileSHA256Vtab11PatchInitPtr, readFileSHA256Vtab11PatchProcessPtr;

--- a/arm9/source/large_patches.s
+++ b/arm9/source/large_patches.s
@@ -225,3 +225,60 @@ _rebootPatchEnd:
 .global rebootPatchSize
 rebootPatchSize:
     .word _rebootPatchEnd - rebootPatch
+
+@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+
+.section .large_patch.readFileSHA256Vtab11, "aw", %progbits
+.arm
+.align 4
+
+.global readFileSHA256Vtab11Patch
+readFileSHA256Vtab11Patch: //Result Write(this, u32 off, u8 *data, u32 size)
+    push {r0-r4, lr}
+
+    sub sp, #0x14
+    push {sp}
+
+    @ DataChainProcessor::DataChainProcessor(&proc);
+    ldr r0, [sp]
+    ldr r4, readFileSHA256Vtab11PatchCtorPtr
+    blx r4
+
+    @ DataChainProcessor::Init(&proc, data, size);
+    ldr r0, [sp]
+    ldr r1, [sp, #0x20]
+    ldr r2, [sp, #0x24]
+    ldr r4, readFileSHA256Vtab11PatchInitPtr
+    blx r4
+
+    @ DataChainProcessor::Process(&proc, this, off, 0, size);
+    ldr r0, [sp]
+
+    ldr r2, [sp, #0x24]
+    str r2, [sp] @ Set size field on stack
+
+    ldr r1, [sp, #0x18]
+    ldr r2, [sp, #0x1c]
+    mov r3, #0
+    ldr r4, readFileSHA256Vtab11PatchProcessPtr
+    blx r4
+
+    add sp, #0x18
+    pop {r0-r4, pc}
+
+.global readFileSHA256Vtab11PatchCtorPtr 
+.global readFileSHA256Vtab11PatchInitPtr
+.global readFileSHA256Vtab11PatchProcessPtr
+
+readFileSHA256Vtab11PatchCtorPtr:       .word   0 @ Pointer to DataChainProcessor::DataChainProcessor
+readFileSHA256Vtab11PatchInitPtr:       .word   0 @ Pointer to DataChainProcessor::Init
+readFileSHA256Vtab11PatchProcessPtr:    .word   0 @ Pointer to DataChainProcessor::ProcessBytes
+
+.pool
+.balign 4
+
+_readFileSHA256Vtab11PatchEnd:
+
+.global readFileSHA256Vtab11PatchSize
+readFileSHA256Vtab11PatchSize:
+    .word _readFileSHA256Vtab11PatchEnd - readFileSHA256Vtab11Patch

--- a/arm9/source/large_patches.s
+++ b/arm9/source/large_patches.s
@@ -236,6 +236,7 @@ rebootPatchSize:
 readFileSHA256Vtab11Patch: //Result Write(this, u32 off, u8 *data, u32 size)
     push {r0-r4, lr}
 
+    @ Allocate memory for DataChainProcessor struct
     sub sp, #0x14
     push {sp}
 
@@ -254,8 +255,8 @@ readFileSHA256Vtab11Patch: //Result Write(this, u32 off, u8 *data, u32 size)
     @ DataChainProcessor::Process(&proc, this, off, 0, size);
     ldr r0, [sp]
 
-    ldr r2, [sp, #0x24]
-    str r2, [sp] @ Set size field on stack
+    ldr r1, [sp, #0x24]
+    str r1, [sp] @ size argument
 
     ldr r1, [sp, #0x18]
     ldr r2, [sp, #0x1c]

--- a/arm9/source/patches.c
+++ b/arm9/source/patches.c
@@ -880,13 +880,13 @@ u32 patchReadFileSHA256Vtab11(u8 *pos, u32 size, u32 process9MemAddr)
 
     if((*ncchVtable11Ptr & 0x1) == 0 || (*shaVtable11Ptr & 0x1) == 0) return 1; //Must be Thumb
 
-    //Find our function address by inspecting all bl branch targets
+    //Find needed function addresses by inspecting all bl branch targets
     u16 *ncchWriteFnc = (u16 *)(pos + ((*ncchVtable11Ptr & ~0x1) - process9MemAddr));
     if(*(u32 *)ncchWriteFnc != 0x0005b5f0) return 1; //Check if we got the right function
 
     readFileSHA256Vtab11PatchCtorPtr = readFileSHA256Vtab11PatchInitPtr = readFileSHA256Vtab11PatchProcessPtr = 0;
 
-    for(; ((*ncchWriteFnc) & 0xff00) != 0xbd00; ncchWriteFnc++) {
+    for(; ((*ncchWriteFnc) & 0xff00) != 0xbd00; ncchWriteFnc++) { //Stop whe encountering a pop {..., pc}
         if((ncchWriteFnc[0] & 0xf800) != 0xf000 || (ncchWriteFnc[1] & 0xf800) != 0xf800) continue; //Check the instruction opcode
 
         s32 callOff = ((ncchWriteFnc[0] & 0x07ff) << 11) | (ncchWriteFnc[1] & 0x07ff);

--- a/arm9/source/patches.c
+++ b/arm9/source/patches.c
@@ -847,3 +847,71 @@ u32 patchLgyK11(u8 *section1, u32 section1Size, u8 *section2, u32 section2Size)
 
     return 0;
 }
+
+static bool getVtableAddress(u8 *pos, u32 size, const u8 *pattern, u32 patternSize, s32 patternOff, u32 memAddr, u32 *vtableAddr)
+{
+    u8 *tmp = memsearch(pos, pattern, size, patternSize);
+
+    if(tmp == NULL) return false;
+
+    u16 *instrPtr = (u16 *)(tmp + patternOff); //ldr rX, [PTR_TO_VTABLE]
+    if((*instrPtr & 0xf800) != 0x4800) return false; //Check the instruction opcode
+
+    *vtableAddr = *(u32 *)(((u32)instrPtr + 4 + 4*(*instrPtr & 0xff)) & ~0x3);
+
+    if(*vtableAddr < memAddr || *vtableAddr >= memAddr + size) return false;
+
+    return true;
+}
+
+u32 patchReadFileSHA256Vtab11(u8 *pos, u32 size, u32 process9MemAddr)
+{
+    static const u8 ncchVtableRefPattern[] = {0x77, 0x46, 0x06, 0x74, 0x47, 0x74};
+    static const u8 shaVtableRefPattern[] = {0x00, 0x1f, 0x01, 0x60, 0x20, 0x30};
+
+    u32 ncchVtableAddr;
+    if(!getVtableAddress(pos, size, ncchVtableRefPattern, sizeof(ncchVtableRefPattern), sizeof(ncchVtableRefPattern), process9MemAddr, &ncchVtableAddr)) return 1;
+
+    u32 shaVtableAddr;
+    if(!getVtableAddress(pos, size, shaVtableRefPattern, sizeof(shaVtableRefPattern), -2, process9MemAddr, &shaVtableAddr)) return 1;
+
+    u32 *ncchVtable11Ptr = (u32 *)(pos + (ncchVtableAddr - process9MemAddr)) + 11,
+        *shaVtable11Ptr = (u32 *)(pos + (shaVtableAddr - process9MemAddr)) + 11;
+
+    if((*ncchVtable11Ptr & 0x1) == 0 || (*shaVtable11Ptr & 0x1) == 0) return 1; //Must be Thumb
+
+    //Find our function address by inspecting all bl branch targets
+    u16 *ncchWriteFnc = (u16 *)(pos + ((*ncchVtable11Ptr & ~0x1) - process9MemAddr));
+    if(*(u32 *)ncchWriteFnc != 0x0005b5f0) return 1; //Check if we got the right function
+
+    readFileSHA256Vtab11PatchCtorPtr = readFileSHA256Vtab11PatchInitPtr = readFileSHA256Vtab11PatchProcessPtr = 0;
+
+    for(; ((*ncchWriteFnc) & 0xff00) != 0xbd00; ncchWriteFnc++) {
+        if((ncchWriteFnc[0] & 0xf800) != 0xf000 || (ncchWriteFnc[1] & 0xf800) != 0xf800) continue; //Check the instruction opcode
+
+        s32 callOff = ((ncchWriteFnc[0] & 0x07ff) << 11) | (ncchWriteFnc[1] & 0x07ff);
+        callOff = (callOff & 0x1fffff) - (callOff & 0x200000);
+
+        u32 callTargetAddr = process9MemAddr + ((u8 *)ncchWriteFnc - pos) + 4 + 2*callOff;
+
+        if(callTargetAddr < process9MemAddr || callTargetAddr >= process9MemAddr + size) return false;
+
+        switch(*(u32 *)(pos + (callTargetAddr - process9MemAddr))) {
+            case 0x60422201: //DataChainProcessor::DataChainProcessor
+                readFileSHA256Vtab11PatchCtorPtr = callTargetAddr | 0x1;
+                break;
+            case 0x000db538: //DataChainProcessor::Init
+                readFileSHA256Vtab11PatchInitPtr = callTargetAddr | 0x1;
+                break;
+            case 0x0006b5f0: //DataChainProcessor::ProcessBytes
+                readFileSHA256Vtab11PatchProcessPtr = callTargetAddr | 0x1;
+                break;
+        }
+    }
+
+    if(readFileSHA256Vtab11PatchCtorPtr == 0 || readFileSHA256Vtab11PatchInitPtr == 0 || readFileSHA256Vtab11PatchProcessPtr == 0) return 1;
+
+    *shaVtable11Ptr = (u32) &readFileSHA256Vtab11Patch; //The patched vtable11 function is in ITCM, so we don't have to copy it somewhere else
+
+    return 0;
+}

--- a/arm9/source/patches.h
+++ b/arm9/source/patches.h
@@ -68,3 +68,4 @@ u32 patchTwlShaHashChecks(u8 *pos, u32 size);
 u32 patchAgbBootSplash(u8 *pos, u32 size);
 void patchTwlBg(u8 *pos, u32 size); // silently fails
 u32 patchLgyK11(u8 *section1, u32 section1Size, u8 *section2, u32 section2Size);
+u32 patchReadFileSHA256Vtab11(u8 *pos, u32 size, u32 process9MemAddr);


### PR DESCRIPTION
Process9's implementation of FSPXI:ReadFileSHA256 uses an auxiliary buffer object when exactly one block of data is being read, which reads the data and hashes it at the same time. This object's `vtable[11]` / `Write` implementation is stubbed (returning error 0xe0c046f8), but can still end up being called when reading from a gamecard NCCH ExeFS file with the NoCrypto flag set.
This patch addresses this by replacing the stubbed implementation with a custom working one.

Solves #1827 

## More details
I've split the exact details & patch details into multiple sections, as it is a quite involved issue involving a lot of specific details and interactions between different parts of the code (in fact it took me about a week of reverse engineering process9 to come up with this patch)

**NOTE:** All process9 offsets / addresses are for the latest FW version at the time of writing (11.16.0-49). All names are my own, and might not line up with existing reverse engineering efforts.

<details><summary>

### Background / `DataBuffer`s
</summary>

Process9's code frequently utilizes a data structure I named `DataBuffer`. This structure is an interface consisting of just a vtable, and is used to represent an abstract store of data which can be read from / written to. Different derived types are used to e.g. implement byte array buffers (vtable at `0x08090d88`), buffers encapsulating type 2 IPC data buffers received from IPC requests (vtable at `0x08091180`), as well as many others.

There are two primary ways to interacting with `DataBuffer` instances:
- the `Read` / `Write` functions, which take a pointer to a buffer, an offset into the `DataBuffer` and a size. If a buffer is e.g. read-only, its `Write` function would return an error.
- `DataBufferChain`s, which manage a list of `DataBuffer`s. When `DataBufferChain::ProcessBytes` is called, it creates a set of queues of physical memory segments. It then employs process9's own threading system to run each `DataBuffer`s `ProcessDataQueue` method in a separate thread, and enqueues a constant supply of empty memory segments into the first buffer's queue. Implementations of this method will then continuously dequeue memory segments, process the data in these segments, then enqueue them into the next buffer's queue once they've finished doing so. Alternatively, `DataBuffer::ProcessDataSegment` can be implemented instead, which will process a single segment at a time - in this case `ProcessDataQueue` simply consists of a call to a helper method which performs the queue management and passes the dequeued segments to this method.

Generally, `DataBufferChain`s seem to be the more "optimal" method - most implementations will implement `ProcessDataQueue`/`ProcessDataSegment` using DMA if possible.

The relevant `DataBuffer` vtable method signatures are:
- `vtable[0]`: `int ProcessDataSegment(this, uint off, DataBufferChain::DataSegment* seg)`
- `vtable[4]`: `int ProcessDataQueue(this, uint off, uint size, DataBufferChain::DataQueue* queue)`
- `vtable[8]`: `int Read(this, uint off, void* data, uint size)`
- `vtable[11]`: `int Write(this, uint off, void* data, uint size)`
- `vtable[12]`: `void AddToChain(this, DataBufferChain* chain, uint off)`
</details>
<details><summary>

### The issue
</summary>

`FSPXI:ReadFileSHA256`'s implementation (`0x08074738`) also utilizes `DataBuffer`s. It checks if the number of bytes to read is exactly one block, and if that's the case, sets up an instance of an auxiliary `DataBuffer` subtype (let's call it `FaultyBuf`) on the stack. It then simply forwards to `FSPXI:ReadFile`, which reads its data into this buffer. `FaultyBuf` not only writes the data into the IPC response buffer, but also hashes it along the way (presumably this edge cast exists to increase performance). Once `FSPXI:ReadFile` returns, the method then proceeds to compare the resulting hash with the one from the hash table, and if they match, returns successfully.

However, **while `FaultyBuf` implements `ProcessDataQueue`, it does not implement `Write`, which is instead stubbed to return error 0xe0c046f8**. To see why this is an issue, one needs to look at the method which eventually handles the read request, `NCCH::ReadEncrypted` (`0x0805c1f4`):
```c
if(key->crypto_type == 0) { //NoCrypto
    return this->ReadBytes(buf, ...);
} else {
    ...
    return this->ReadThroughNCCHBuf(..., buf, ...);
}
```
`NCCH::ReadBytes` (`0x0805e1f0`) eventually ends up calling `DataBuffer::Write` on the buffer it was given (at least for gamecards, its behavior might differ for installed / other titles). **This results in an error when the `NoCrypto` flag is set, as in this case the `FaultyBuf` instance is passed through directly, which does not implement `Write`.**

`NCCH::ReadThroughNCCHBuf` (`0x080334a0`) on the other hand passes its own `DataBuffer` implementation to `ReadBytes` instead (which I named `NCCHEncryptedDataBuffer`, vtable at `0x08092620`), which does implement `Write`. After it decrypted the raw data, it then accesses the original data buffer through the `DataBufferChain` mechanism, which is properly implemented by `FaultyBuf`.

The amount of specific details / requirements involved in this issue lead me to believe that this is not an intentional security check, but a bug in Nintendo's firmware.
</details>
<details><summary>

### The patch
</summary>

The correct way to fix this issue can be found in `NCCHEncryptedDataBuffer`'s `Write` implementation (`0x08070610`):
```c
if ((this->force_blocks != 0) && (((off & 0x1ff) != 0 || (size != 0x200)))) {
    panic();
}

DataChainProcessor proc;
proc.Init(data, size);
ret proc.ProcessBytes(this, off, 0, size);
```
`NCCHEncryptedDataBuffer` only implements its logic in `ProcessDataQueue`/`ProcessDataSegment`, same as `FaultyBuf`. However, in its `Write` implementation, it uses a helper class called `DataChainProcessor` to complete the request instead of returning an error code. The helper class sets up a temporary `DataBufferChain`, which is then used to transfer the source buffer's contents into the given `DataBuffer`. As such, this issue can be fixed by replicating that same behavior for `FaultyBuf::Write` as well.

However, it's not possible to just redirect `FaultyBuf::Write` to `NCCHEncryptedDataBuffer::Write`, as their memory layouts aren't compatible (in particular, the first `if` check will read garbage). Instead, it's necessary to craft a custom implementation of this method in either free space or ITCM, and patch the vtable to point to this method instead (this PR places the function in ITCM as I could not find any other suitable spots).

The patched method needs to reference three other functions: `DataChainProcessor::DataChainProcessor`, `DataChainProcesssor::Init` and `DataChainProcessor::ProcessBytes`. The location of all three methods can be determined by iterating over all functions called by `NCCHEncryptedDataBuffer::Write` (by decoding all `bl` instructions in the method), and checking the first 4 bytes of the method's code as a sort of "method signature" to distinguish between the different methods (this approach is implemented in this PR).
</details>

## Results
The following screenshot was taken on a version of Luma3DS with this patch applied, by inserting a Sky3DS+ flashcart loaded with a CCI created from `FBI.cia` using `makerom` (note that it might be required to fixup the ROM's title key using a script [like this](https://gist.github.com/Popax21/a85f4dce14bd486b924be7c1e097e238), or the flashcart might label the ROM as bad):

![top](https://user-images.githubusercontent.com/29798799/211687964-23d04469-8497-43cc-a1ad-c65bd4b3e282.png)
![bot](https://user-images.githubusercontent.com/29798799/211687970-ddb1fb95-81e9-4d4e-b236-b69796e3b6d3.png)

Without this PR, the 3DS wouldn't pick up the cartridge at all, as the home menu's call to `FSUSER:ReadFileDirectly` to read the cartridge's `icon` file would have failed.