### PR TITLE
Improved system modules speed

### DIFF
--- a/arm9/source/patches.c
+++ b/arm9/source/patches.c
@@ -233,6 +233,7 @@ u32 patchKernel11(u8 *pos, u32 size, u32 baseK11VA, u32 *arm11SvcTable, u32 *arm
 {
     static const u8 patternKPanic[] = {0x02, 0x0B, 0x44, 0xE2};
     static const u8 patternKThreadDebugReschedule[] = {0x34, 0x20, 0xD4, 0xE5, 0x00, 0x00, 0x55, 0xE3, 0x80, 0x00, 0xA0, 0x13};
+    static const u8 patternSuspendThread[] = {0xB0, 0x01, 0xD5, 0xE1, 0x01, 0x00, 0x50, 0xE3};
 
     //Assumption: ControlMemory, DebugActiveProcess and KernelSetState are in the first 0x20000 bytes
     //Patch ControlMemory
@@ -294,6 +295,23 @@ u32 patchKernel11(u8 *pos, u32 size, u32 baseK11VA, u32 *arm11SvcTable, u32 *arm
                 return 1;
             off[1] = 0xEA000003;
         }
+    }
+
+    // Patch core #1 usage limit.
+    // When game/homebrew apps use APT_SetAppCpuTimeLimit(), it will limit the time
+    // allowed to run system thread even if user threads use little CPU time.
+    // e.g. Let's say we called APT_SetAppCpuTimeLimit(60);
+    // Then, 60% of CPU time will constantly be allocated to user threads
+    // by suspending system threads even when user app uses little cpu time
+    // so that system thread can run only use 40% of CPU time.
+    // This will cause significant slow down for system modules such as fs, httpc, y2r, mvd etc...
+    // This patch disables "suspending system threads" behavior so that if user threads
+    // use little CPU time, then system threads can use rest of CPU time.
+    off = (u32 *)memsearch(pos, patternSuspendThread, size, sizeof(patternSuspendThread));
+    if(off)
+    {
+        //We are replacing if(core_id == 1) with if(core_id == 4) so that it will always be false.
+        off[1] = 0x040050E3;//cmp r0, #0x1 -> cmp r0, #0x4
     }
 
     return 0;


### PR DESCRIPTION
This PR improves system modules speed when using APT_SetAppCpuTimeLimit().

When app calls APT_SetAppCpuTimeLimit(app_cpu_time), it will limit the time allowed to run system threads even if user threads use little CPU time.
It means even app threads use little CPU time, system threads on core 1 can only use (100 - app_cpu_time)%, and will cause significant slow down for system modules such as fs, httpc, y2r, mvd etc...

This patch disables "limit the time allowed to run system threads" behavior so that if user threads use little CPU time, then system threads can use rest of CPU time.
This patch also makes core 1 completely available to user apps (so app_cpu_time has no effect here, but you still need to call APT_SetAppCpuTimeLimit() to allow creating thread on core 1).

I made the [test app](https://github.com/LumaTeam/Luma3DS/files/11723867/Core_1_patch_tester.zip) that uses y2r (hardware color conversion) service to test it.
Here is the test results on NEW 3DS :
```
y2r means the response time of y2r service.
core 1 speed means how fast the thread on core 1 opereates.
(see source code for detail)
```
| | Official Luma3DS v12.0.1<br>(likely on older versions too) | Official Luma3DS v12.0.1 + this patch |
|-|-|-|
|APT_SetAppCpuTimeLimit(**5**)<br>**No** user app threads on core 1| y2r : 2.3ms<br> core 1 speed : n/a | y2r : 2.3ms<br> core 1 speed : n/a |
|APT_SetAppCpuTimeLimit(**80**)<br>**No** user app threads on core 1| y2r : 4.0ms<br>core 1 speed : n/a | y2r : 2.3ms<br> core 1 speed : n/a |
|APT_SetAppCpuTimeLimit(**5**)<br>1 user app thread on core 1| y2r : 2.3ms<br>core 1 speed : 23 | y2r : 2.3ms<br> core 1 speed : 480 |
|APT_SetAppCpuTimeLimit(**80**)<br>1 user app thread on core 1| y2r : 3.9ms<br>core 1 speed : 422 | y2r : 2.3ms<br> core 1 speed : 481 |

As you can see, even there's no user thread on core 1, system modules slow down significantly on original firmware.
On patched firmware, even there's a thread running on core 1, system modules won't slow down (of course, it will slow down if you create a thread on core 1 at too high priority).