### PR TITLE
Expose the booted Luma3DS .firm location with svcGetSystemInfo

### DIFF
--- a/arm9/source/patches.c
+++ b/arm9/source/patches.c
@@ -44,6 +44,8 @@
 
 #define K11EXT_VA         0x70000000
 
+extern u16 launchedPath[];
+
 u8 *getProcess9Info(u8 *pos, u32 size, u32 *process9Size, u32 *process9MemAddr)
 {
     u8 *temp = memsearch(pos, "NCCH", size, 4);
@@ -139,6 +141,8 @@ u32 installK11Extension(u8 *pos, u32 size, bool needToInitSd, u32 baseK11VA, u32
 
             u64 autobootTwlTitleId;
             u8 autobootCtrAppmemtype;
+
+            u16 launchedPath[80+1];
         } info;
     };
 
@@ -225,6 +229,8 @@ u32 installK11Extension(u8 *pos, u32 size, bool needToInitSd, u32 baseK11VA, u32
     if(ISN3DS) info->flags |= 1 << 4;
     if(needToInitSd) info->flags |= 1 << 5;
     if(isSdMode) info->flags |= 1 << 6;
+
+    memcpy(info->launchedPath, launchedPath, sizeof(info->launchedPath));
 
     return 0;
 }

--- a/k11_extension/include/globals.h
+++ b/k11_extension/include/globals.h
@@ -146,6 +146,8 @@ typedef struct CfwInfo
 
     u64 autobootTwlTitleId;
     u8 autobootCtrAppmemtype;
+
+    u16 launchedPath[80+1];
 } CfwInfo;
 
 extern CfwInfo cfwInfo;

--- a/k11_extension/source/svc/GetSystemInfo.c
+++ b/k11_extension/source/svc/GetSystemInfo.c
@@ -37,7 +37,14 @@ Result GetSystemInfoHook(s64 *out, s32 type, s32 param)
     {
         case 0x10000:
         {
-            switch(param)
+            if (param >= 0x400 && param < 0x500) {
+                *out = 0;
+                s32 offset = param - 0x400;
+                s32 toCopy = (s32)sizeof(cfwInfo.launchedPath) - offset;
+                if (toCopy > 8) toCopy = 8;
+                memcpy(out, (u8*)cfwInfo.launchedPath + offset, (toCopy > 0) ? toCopy : 0);
+            } 
+            else switch(param)
             {
                 // Please do not use these, except 0, 1, and 0x200
                 // Other types may get removed or reordered without notice


### PR DESCRIPTION
This PR adds svcGetSystemInfo type 0x10000 and param range 0x400 to 0x500. This way, it is possible to obtain the path of the launched `.firm` file. This can be used by tools that update Luma3DS to know what file to update (for example, the user may be booting the `.firm` from `luma/payloads` instead of `boot.firm`). It also allows verifying the `.firm` actually comes from the SD instead of NAND or FIRM0/1, which helps identify SD corruption issues and promt users in the right direction.

Here is an example C code to obtain the boot path:
```c
static u8 launchPathBuffer[256] = {0};
static char launchPathUTF8[256] = {0};
char* getLumaBootPath() {
    for (int i = 0; i < 0x100; i+=8) {
        svcGetSystemInfo((s64*)(launchPathBuffer + i), 0x10000, 0x400 + i);
    }
    utf16_to_utf8((u8*)launchPathUTF8, (u16*)launchPathBuffer, 255);
    return launchPathUTF8;
}
// Inside main()
// ...
printf(getLumaBootPath());
// ...
```