### PR TITLE
Fix plugin home menu event notification

### DIFF
--- a/sysmodules/rosalina/source/plugin/memoryblock.c
+++ b/sysmodules/rosalina/source/plugin/memoryblock.c
@@ -277,5 +277,5 @@ void       MemoryBlock__ResetSwapSettings(void)
 
 PluginHeader* MemoryBlock__GetMappedPluginHeader() {
     MemoryBlock     *memblock = &PluginLoaderCtx.memblock;
-    return memblock->isReady ? NULL : (PluginHeader*)memblock->memblock;
+    return memblock->isReady ? (PluginHeader*)memblock->memblock : NULL;
 }

--- a/sysmodules/rosalina/source/plugin/plgloader.c
+++ b/sysmodules/rosalina/source/plugin/plgloader.c
@@ -563,7 +563,9 @@ void    PluginLoader__HandleKernelEvent(u32 notifId)
             ctx->pluginIsSwapped = !ctx->pluginIsSwapped;
         } else {
             // Needed for compatibility with old plugins that don't expect the PLG_HOME events.
-            volatile PluginHeader* mappedHeader = PA_FROM_VA_PTR(MemoryBlock__GetMappedPluginHeader());
+            // Evades cache by using physical address.
+            volatile PluginHeader* mappedHeader = MemoryBlock__GetMappedPluginHeader();
+            mappedHeader = mappedHeader ? PA_FROM_VA_PTR(mappedHeader) : NULL;
             bool doNotification = mappedHeader ? mappedHeader->notifyHomeEvent : false;
             if (ctx->pluginIsHome)
             {


### PR DESCRIPTION
Fixes wrong logic to determine if plugins should get home menu notifications, which fixes apps running older plugins taking 10+ seconds to jump to the home menu and back.