### PR TITLE
Don't copy to CTRNAND if building for exploit mode

### DIFF
--- a/arm9/source/fs.c
+++ b/arm9/source/fs.c
@@ -523,8 +523,10 @@ bool doLumaUpgradeProcess(void)
 #endif
 
     // Try to boot.firm to CTRNAND, when applicable
+#ifndef BUILD_FOR_EXPLOIT_DEV
     if (isSdMode && memcmp(launchedPathForFatfs, "sdmc:", 5) == 0)
         ok = fileCopy(launchedPathForFatfs, "nand:/boot.firm", true, fileCopyBuffer, sizeof(fileCopyBuffer));
+#endif
 
     // Try to backup essential files
     ok2 = backupEssentialFiles();


### PR DESCRIPTION
While the copy to NAND process is generally a good idea for end users, this can quickly get annoying for actual developers looking to test low level stuff or contribute to Luma3DS if a testing FIRM gets sent to the NAND.

This is sort of a hack, and I'm not sure what's a better way to improve this. Maybe it's a good idea to add a "release build" flag in the build makefiles so that this particular code only gets added when explicitly built that way.

**I don't know how to test this code**, as there are checks that are done prior to the copy step (i.e. checking Luma's MCU free regs for current version... how to override that?) so I can't seem to get stock Luma3DS to copy to NAND. Thus this is effectively untested.