### PR TITLE
Fix luma config softlock (#1931)

### DIFF
--- a/arm9/source/config.c
+++ b/arm9/source/config.c
@@ -1064,7 +1064,8 @@ void configMenu(bool oldPinStatus, u32 oldPinMode)
         if(pressed & BUTTON_START) 
         {
             startPressed = true;
-            pressed |= (BUTTON_RIGHT);
+            // This moves the cursor to the last entry
+            pressed = BUTTON_RIGHT;
         }
 
         if(pressed & DPAD_BUTTONS)


### PR DESCRIPTION
Fixes wrong logic that could cause a softlock if a DPAD direction is hold at the same time of pressing start. 