### PR TITLE
Add GitHub Actions Workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+    paths-ignore:
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/*'
+      - 'LICENSE.txt'
+      - 'README.md'
+  pull_request:
+    paths-ignore:
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/*'
+      - 'LICENSE.txt'
+      - 'README.md'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: pablomk7/luma3dsbuildtools
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: safedir
+      run: git config --system --add safe.directory /__w/Luma3DS/Luma3DS
+    - name: debug
+      run: git describe --tags
+    - name: Build
+      run: make -j$(nproc --all)
+    - uses: actions/upload-artifact@v3
+      with:
+        name: Luma3DS
+        path: boot.firm

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,8 +25,6 @@ jobs:
         fetch-depth: 0
     - name: safedir
       run: git config --system --add safe.directory /__w/Luma3DS/Luma3DS
-    - name: debug
-      run: git describe --tags
     - name: Build
       run: make -j$(nproc --all)
     - uses: actions/upload-artifact@v3


### PR DESCRIPTION
This pull request adds a GitHub action, building the .FIRM files after every push. This makes things easier and doesn't require the developers to manually build everytime on their computer. It will build and be added as an "artifact", a ZIP archive that you can download from the run page of the workflow and contains the .FIRM file which can then be extracted and uploaded for a new release if it is done for a new release.

P.S.: I made this PR before, but I needed to sync changes which caused my repository's changes to be lost and closed the PR. This new PR contains my changes and the new upstream changes.