### PR TITLE
Add playcoin maxing feature to rosalina

### DIFF
--- a/sysmodules/rosalina/include/menus/miscellaneous.h
+++ b/sysmodules/rosalina/include/menus/miscellaneous.h
@@ -38,3 +38,4 @@ void MiscellaneousMenu_InputRedirection(void);
 void MiscellaneousMenu_UpdateTimeDateNtp(void);
 void MiscellaneousMenu_NullifyUserTimeOffset(void);
 void MiscellaneousMenu_DumpDspFirm(void);
+void MiscellaneousMenu_MaxPlayCoins(void);


### PR DESCRIPTION
This adds an option to set the Play Coins to 300 in the rosalina menu.
I made it an option in the Miscellaneous options. 
Useful when you want to mass spend play coins without visiting other apps to get them back to 300 first.

I hope you're fine with the amount of comments in my code! :\)