### PR TITLE
Add more mountpoint names for LayeredFS updates

### DIFF
--- a/sysmodules/loader/source/patcher.c
+++ b/sysmodules/loader/source/patcher.c
@@ -579,7 +579,9 @@ static inline bool patchLayeredFs(u64 progId, u8 *code, u32 size, u32 textSize, 
     if(!findLayeredFsSymbols(code, textSize, &fsMountArchive, &fsRegisterArchive, &fsTryOpenFile, &fsOpenFileDirectly) ||
        !findLayeredFsPayloadOffset(code, textSize, roSize, dataSize, roAddress, dataAddress, &payloadOffset, &pathOffset, &pathAddress)) return false;
 
-    static const char *updateRomFsMounts[] = { "rom2:",
+    static const char *updateRomFsMounts[] = { "ro2:",
+                                               "pat1",
+                                               "rom2:",
                                                "rex:",
                                                "patch:",
                                                "ext:",

--- a/sysmodules/loader/source/patcher.c
+++ b/sysmodules/loader/source/patcher.c
@@ -580,12 +580,12 @@ static inline bool patchLayeredFs(u64 progId, u8 *code, u32 size, u32 textSize, 
        !findLayeredFsPayloadOffset(code, textSize, roSize, dataSize, roAddress, dataAddress, &payloadOffset, &pathOffset, &pathAddress)) return false;
 
     static const char *updateRomFsMounts[] = { "ro2:",
-                                               "pat1",
                                                "rom2:",
                                                "rex:",
                                                "patch:",
                                                "ext:",
-                                               "rom:" };
+                                               "rom:",
+                                               "pat1"};
     u32 updateRomFsIndex;
 
     //Locate update RomFSes

--- a/sysmodules/loader/source/patcher.c
+++ b/sysmodules/loader/source/patcher.c
@@ -584,18 +584,36 @@ static inline bool patchLayeredFs(u64 progId, u8 *code, u32 size, u32 textSize, 
                                                "rex:",
                                                "patch:",
                                                "ext:",
-                                               "rom:",
-                                               "pat1"};
-    u32 updateRomFsIndex;
+                                               "rom:" };
 
-    //Locate update RomFSes
-    for(updateRomFsIndex = 0; updateRomFsIndex < sizeof(updateRomFsMounts) / sizeof(char *) - 1; updateRomFsIndex++)
+    bool isMarioKart7 = progId == 0x0004000000030600LL || //JPN MK7
+                        progId == 0x0004000000030700LL || //EUR MK7
+                        progId == 0x0004000000030800LL || //USA MK7
+                        progId == 0x0004000000030A00LL || //KOR MK7
+                        progId == 0x000400000008B400LL;   //TWN MK7
+                        // Exclude CHN as it never got updates
+
+    char *updateRomFsMount;
+
+    if (isMarioKart7)
     {
-        u32 patternSize = strlen(updateRomFsMounts[updateRomFsIndex]);
-        u8 temp[7];
-        temp[0] = 0;
-        memcpy(temp + 1, updateRomFsMounts[updateRomFsIndex], patternSize);
-        if(memsearch(code, temp, size, patternSize + 1) != NULL) break;
+        updateRomFsMount = (char*)"pat1"; // Isolated to prevent false-positives
+    }
+    
+    else
+    {
+        u32 updateRomFsIndex;
+
+        //Locate update RomFS
+        for(updateRomFsIndex = 0; updateRomFsIndex < sizeof(updateRomFsMounts) / sizeof(char *) - 1; updateRomFsIndex++)
+        {
+            u32 patternSize = strlen(updateRomFsMounts[updateRomFsIndex]);
+            u8 temp[7];
+            temp[0] = 0;
+            memcpy(temp + 1, updateRomFsMounts[updateRomFsIndex], patternSize);
+            if(memsearch(code, temp, size, patternSize + 1) != NULL) break;
+        }
+        updateRomFsMount = (char*)updateRomFsMounts[updateRomFsIndex];
     }
 
     //Setup the payload
@@ -609,7 +627,7 @@ static inline bool patchLayeredFs(u64 progId, u8 *code, u32 size, u32 textSize, 
     romfsRedirPatchFsMountArchive = 0x100000 + fsMountArchive;
     romfsRedirPatchFsRegisterArchive = 0x100000 + fsRegisterArchive;
     romfsRedirPatchArchiveId = archiveId;
-    memcpy(&romfsRedirPatchUpdateRomFsMount, updateRomFsMounts[updateRomFsIndex], 4);
+    memcpy(&romfsRedirPatchUpdateRomFsMount, updateRomFsMount, 4);
 
     memcpy(payload, romfsRedirPatch, romfsRedirPatchSize);
 

--- a/sysmodules/loader/source/patcher.c
+++ b/sysmodules/loader/source/patcher.c
@@ -586,18 +586,18 @@ static inline bool patchLayeredFs(u64 progId, u8 *code, u32 size, u32 textSize, 
                                                "ext:",
                                                "rom:" };
 
-    bool isMarioKart7 = progId == 0x0004000000030600LL || //JPN MK7
-                        progId == 0x0004000000030700LL || //EUR MK7
-                        progId == 0x0004000000030800LL || //USA MK7
-                        progId == 0x0004000000030A00LL || //KOR MK7
-                        progId == 0x000400000008B400LL;   //TWN MK7
+    bool isMarioKart7 = (u32)progId == 0x00030600 || //JPN MK7
+                        (u32)progId == 0x00030700 || //EUR MK7
+                        (u32)progId == 0x00030800 || //USA MK7
+                        (u32)progId == 0x00030A00 || //KOR MK7
+                        (u32)progId == 0x0008B400;   //TWN MK7
                         // Exclude CHN as it never got updates
 
-    char *updateRomFsMount;
+    const char *updateRomFsMount;
 
     if (isMarioKart7)
     {
-        updateRomFsMount = (char*)"pat1"; // Isolated to prevent false-positives
+        updateRomFsMount = "pat1"; // Isolated to prevent false-positives
     }
     
     else
@@ -613,7 +613,7 @@ static inline bool patchLayeredFs(u64 progId, u8 *code, u32 size, u32 textSize, 
             memcpy(temp + 1, updateRomFsMounts[updateRomFsIndex], patternSize);
             if(memsearch(code, temp, size, patternSize + 1) != NULL) break;
         }
-        updateRomFsMount = (char*)updateRomFsMounts[updateRomFsIndex];
+        updateRomFsMount = updateRomFsMounts[updateRomFsIndex];
     }
 
     //Setup the payload


### PR DESCRIPTION
Mario Kart 7 uses the mountpoint name `pat1` for its update.
SmileBASIC 3 (and probably other SmileBoom titles that got updates) use `ro2:`

This is in reference to my issue #1993.
I haven't really got the drill of PR's just yet but I hope it works.