### PR TITLE
plugin_loader: Add new flags to 3gx files

### DIFF
--- a/sysmodules/rosalina/include/plugin/3gx.h
+++ b/sysmodules/rosalina/include/plugin/3gx.h
@@ -20,7 +20,10 @@ typedef struct CTR_PACKED
             u32     embeddedExeLoadFunc : 1;
             u32     embeddedSwapSaveLoadFunc : 1;
             u32     memoryRegionSize : 2;
-            u32     unused : 28;
+            u32     compatibility : 2;
+            u32     eventsSelfManaged : 1;
+            u32     swapNotNeeded : 1;
+            u32     unused : 24;
         };
     };
     u32             exeLoadChecksum;
@@ -66,6 +69,12 @@ typedef struct CTR_PACKED
     _3gx_Symtable   symtable;
 } _3gx_Header;
 
+
+enum _3gx_Compatibility {
+    PLG_COMPAT_CONSOLE = 0,
+    PLG_COMPAT_EMULATOR = 1,
+    PLG_COMPAT_CONSOLE_EMULATOR = 2,
+};
 
 Result  Check_3gx_Magic(IFile *file);
 Result  Read_3gx_Header(IFile *file, _3gx_Header *header);

--- a/sysmodules/rosalina/include/plugin/plgloader.h
+++ b/sysmodules/rosalina/include/plugin/plgloader.h
@@ -91,6 +91,8 @@ typedef struct
     u8              pluginMemoryStrategy;
     u32             exeLoadChecksum;
     u32             swapLoadChecksum;    
+
+    bool            eventsSelfManaged;
 }   PluginLoaderContext;
 
 extern PluginLoaderContext PluginLoaderCtx;

--- a/sysmodules/rosalina/source/plugin/file_loader.c
+++ b/sysmodules/rosalina/source/plugin/file_loader.c
@@ -205,6 +205,19 @@ bool     TryToLoadPlugin(Handle process)
     if (!res && R_FAILED((res = Read_3gx_Header(&plugin, &fileHeader))))
         ctx->error.message = "Couldn't read file";
 
+    // Check compatibility
+    if (!res && fileHeader.infos.compatibility == PLG_COMPAT_EMULATOR) {
+        ctx->error.message = "Plugin is only compatible with emulators";
+        return false;
+    }
+
+    // Flags
+    if (!res) {
+        ctx->eventsSelfManaged = fileHeader.infos.eventsSelfManaged;
+        if (ctx->pluginMemoryStrategy == PLG_STRATEGY_SWAP && fileHeader.infos.swapNotNeeded)
+            ctx->pluginMemoryStrategy = PLG_STRATEGY_NONE;
+    }
+
     // Set memory region size according to header
     if (!res && R_FAILED((res = MemoryBlock__SetSize(memRegionSizes[fileHeader.infos.memoryRegionSize])))) {
         ctx->error.message = "Couldn't set memblock size.";


### PR DESCRIPTION
Adds the following flags to 3gx files:
- `EventsSelfManaged` the plugin loader will not send events to the plugin, and the plugin will be responsible to handle itself.
- `SwapNotNeeded` disables the swap mechanism in o3ds models.