### PR TITLE
plugin loader: add persistent plugin user load parameters

### DIFF
--- a/sysmodules/rosalina/include/plugin/plgldr.h
+++ b/sysmodules/rosalina/include/plugin/plgldr.h
@@ -11,6 +11,7 @@ typedef struct
 {
     bool    noFlash;
     u8      pluginMemoryStrategy;
+    u8      persistent;
     u32     lowTitleId;
     char    path[256];
     u32     config[32];

--- a/sysmodules/rosalina/source/plugin/file_loader.c
+++ b/sysmodules/rosalina/source/plugin/file_loader.c
@@ -170,7 +170,7 @@ bool     TryToLoadPlugin(Handle process)
     // Try to open plugin file
     if (ctx->useUserLoadParameters && (ctx->userLoadParameters.lowTitleId == 0 || (u32)tid == ctx->userLoadParameters.lowTitleId))
     {
-        ctx->useUserLoadParameters = false;
+        if (!ctx->userLoadParameters.persistent) ctx->useUserLoadParameters = false;
         ctx->pluginMemoryStrategy = ctx->userLoadParameters.pluginMemoryStrategy;
         if (OpenFile(&plugin, ctx->userLoadParameters.path))
             return false;


### PR DESCRIPTION
Allows plugin load parameters to persist between game launches and Mode3 reboots. Plugins can then clear persistent parameters with a new service call.