### PR TITLE
rosalina: Add debug flag to dump gdb communications

### DIFF
--- a/sysmodules/rosalina/include/gdb.h
+++ b/sysmodules/rosalina/include/gdb.h
@@ -16,6 +16,9 @@
 #include "memory.h"
 #include "ifile.h"
 
+// Uncomment the line below to dump GDB communications to a file
+//#define DEBUG_GDB_COMMUNICATIONS
+
 #define MAX_DEBUG           3
 #define MAX_DEBUG_THREAD    127
 #define MAX_BREAKPOINT      64
@@ -154,6 +157,10 @@ typedef struct GDBContext
 
     char memoryOsInfoXmlData[0x800];
     char processesOsInfoXmlData[0x1800];
+
+#ifdef DEBUG_GDB_COMMUNICATIONS
+    IFile debugFile;
+#endif
 } GDBContext;
 
 typedef int (*GDBCommandHandler)(GDBContext *ctx);

--- a/sysmodules/rosalina/include/ifile.h
+++ b/sysmodules/rosalina/include/ifile.h
@@ -44,3 +44,4 @@ Result IFile_GetSize(IFile *file, u64 *size);
 Result IFile_SetSize(IFile *file, u64 size);
 Result IFile_Read(IFile *file, u64 *total, void *buffer, u32 len);
 Result IFile_Write(IFile *file, u64 *total, const void *buffer, u32 len, u32 flags);
+Result IFile_Flush(IFile *file);

--- a/sysmodules/rosalina/source/gdb.c
+++ b/sysmodules/rosalina/source/gdb.c
@@ -28,6 +28,10 @@ void GDB_InitializeContext(GDBContext *ctx)
     ctx->eventToWaitFor = ctx->processAttachedEvent;
     ctx->continueFlags = (DebugFlags)(DBG_SIGNAL_FAULT_EXCEPTION_EVENTS | DBG_INHIBIT_USER_CPU_EXCEPTION_HANDLERS);
 
+#ifdef DEBUG_GDB_COMMUNICATIONS
+    IFile_Open(&ctx->debugFile, ARCHIVE_SDMC, fsMakePath(PATH_EMPTY, ""), fsMakePath(PATH_ASCII, "/luma/gdb_debug.txt"), FS_OPEN_READ | FS_OPEN_WRITE | FS_OPEN_CREATE);
+#endif
+
     RecursiveLock_Unlock(&ctx->lock);
 }
 
@@ -39,6 +43,10 @@ void GDB_FinalizeContext(GDBContext *ctx)
 
     svcCloseHandle(ctx->processAttachedEvent);
     svcCloseHandle(ctx->continuedEvent);
+
+#ifdef DEBUG_GDB_COMMUNICATIONS
+    IFile_Close(&ctx->debugFile);
+#endif
 
     RecursiveLock_Unlock(&ctx->lock);
 }

--- a/sysmodules/rosalina/source/ifile.c
+++ b/sysmodules/rosalina/source/ifile.c
@@ -149,3 +149,8 @@ Result IFile_Write(IFile *file, u64 *total, const void *buffer, u32 len, u32 fla
   *total = cur;
   return res;
 }
+
+Result IFile_Flush(IFile *file)
+{
+  return FSFILE_Flush(file->handle);
+}


### PR DESCRIPTION
Adds a flag in DEBUG_GDB_COMMUNICATIONS (normally disabled) that helps debugging the GDB protocol by saving the traffic to a file.