### PR TITLE
Add basic support for prototype firmware

### DIFF
--- a/arm9/source/firm.h
+++ b/arm9/source/firm.h
@@ -35,4 +35,5 @@ u32 patchNativeFirm(u32 firmVersion, FirmwareSource nandType, bool loadFromStora
 u32 patchTwlFirm(u32 firmVersion, bool loadFromStorage, bool doUnitinfoPatch);
 u32 patchAgbFirm(bool loadFromStorage, bool doUnitinfoPatch);
 u32 patch1x2xNativeAndSafeFirm(void);
+u32 patchPrototypeNative(void);
 void launchFirm(int argc, char **argv);

--- a/arm9/source/main.c
+++ b/arm9/source/main.c
@@ -386,6 +386,9 @@ boot:
         case NATIVE_FIRM1X2X:
             res = patch1x2xNativeAndSafeFirm();
             break;
+        case NATIVE_PROTOTYPE:
+            res = patchPrototypeNative();
+            break;
     }
 
     if(res != 0) error("Failed to apply %u FIRM patch(es).", res);

--- a/arm9/source/patches.h
+++ b/arm9/source/patches.h
@@ -31,6 +31,7 @@
 *   FIRM partition writes patches by delebile
 *   Idea for svcBreak patches from yellows8 and others on #3dsdev
 *   TWL_FIRM patches by Steveice10 and others
+*   Signature patches for prototype FW by PabloMK7
 */
 
 #pragma once
@@ -68,3 +69,4 @@ u32 patchTwlShaHashChecks(u8 *pos, u32 size);
 u32 patchAgbBootSplash(u8 *pos, u32 size);
 void patchTwlBg(u8 *pos, u32 size); // silently fails
 u32 patchLgyK11(u8 *section1, u32 section1Size, u8 *section2, u32 section2Size);
+u32 patchProtoNandSignatureCheck(u8 *pos, u32 size);

--- a/arm9/source/types.h
+++ b/arm9/source/types.h
@@ -134,7 +134,8 @@ typedef enum FirmwareType
     AGB_FIRM,
     SAFE_FIRM,
     SYSUPDATER_FIRM,
-    NATIVE_FIRM1X2X
+    NATIVE_FIRM1X2X,
+    NATIVE_PROTOTYPE,
 } FirmwareType;
 
 typedef enum bootType


### PR DESCRIPTION
* Installs arm9 exception handlers
* Disables NAND signature checks, allowing the firmware to boot on retail devices