### PR TITLE
Add option to force game updates by overriding title's remaster version

### DIFF
--- a/sysmodules/loader/source/loader.c
+++ b/sysmodules/loader/source/loader.c
@@ -349,20 +349,30 @@ static Result GetProgramInfoImpl(ExHeader_Info *exheaderInfo, u64 programHandle)
     else
     {
         bool exhLoadedExternally = false;
+        bool remasterVersionOverridden = false;
         if (CONFIG(PATCHGAMES))
         {
             // Require both "load external FIRM & modules" and "patch games" for sysmodules
             if (IsSysmoduleId(originalTitleId))
+            {
                 exhLoadedExternally = CONFIG(LOADEXTFIRMSANDMODULES);
+                remasterVersionOverridden = CONFIG(LOADEXTFIRMSANDMODULES);
+            }
             else
+            {
                 exhLoadedExternally = true;
+                remasterVersionOverridden = true;
+            }
         }
 
         if (exhLoadedExternally)
             exhLoadedExternally = loadTitleExheaderInfo(originalTitleId, exheaderInfo);
 
-        if(exhLoadedExternally)
+        if (exhLoadedExternally)
             exheaderInfo->aci.local_caps.title_id = originalTitleId;
+
+        if (remasterVersionOverridden)
+            remasterVersionOverridden = overrideTitleRemasterVersion(originalTitleId, &(exheaderInfo->sci.codeset_info.flags.remaster_version));
     }
     
     if (IsApplicationId(originalTitleId)) {

--- a/sysmodules/loader/source/patcher.c
+++ b/sysmodules/loader/source/patcher.c
@@ -465,6 +465,44 @@ error:
     while(true);
 }
 
+bool overrideTitleRemasterVersion(u64 progId, u16 *remasterVersion)
+{
+    /* Here we look for "/luma/titles/[u64 titleID in hex, uppercase]/remaster.bin"
+       If it exists it should contain a 16-bit integer */
+
+    char path[] = "/luma/titles/0000000000000000/remaster.bin";
+    progIdToStr(path + 28, progId);
+
+    IFile file;
+    u16 targetVersion;
+
+    if(!openLumaFile(&file, path)) return false;
+
+    u64 fileSize;
+
+    if(R_FAILED(IFile_GetSize(&file, &fileSize)) || (fileSize != 2)) goto error;
+    else
+    {
+        u64 total;
+
+        if(R_FAILED(IFile_Read(&file, &total, &targetVersion, 2)) || total != 2) goto error;
+    }
+
+    IFile_Close(&file);
+
+    // force the target version to be treated as the "newest" remaster version available
+    if (targetVersion >= *remasterVersion) return false;
+    *remasterVersion = 0;
+
+    return true;
+
+error:
+    IFile_Close(&file);
+
+    svcBreak(USERBREAK_ASSERT);
+    while(true);
+}
+
 static inline bool loadTitleLocaleConfig(u64 progId, u8 *mask, u8 *regionId, u8 *languageId, u8 *countryId, u8 *stateId)
 {
     /* Here we look for "/luma/titles/[u64 titleID in hex, uppercase]/locale.txt"

--- a/sysmodules/loader/source/patcher.h
+++ b/sysmodules/loader/source/patcher.h
@@ -48,6 +48,7 @@ extern bool isN3DS, isSdMode, nextGamePatchDisabled, isLumaWithKext;
 void patchCode(u64 progId, u16 progVer, u8 *code, u32 size, u32 textSize, u32 roSize, u32 dataSize, u32 roAddress, u32 dataAddress);
 bool loadTitleCodeSection(u64 progId, u8 *code, u32 size);
 bool loadTitleExheaderInfo(u64 progId, ExHeader_Info *exheaderInfo);
+bool overrideTitleRemasterVersion(u64 progId, u16 *remasterVersion);
 
 Result openSysmoduleCxi(IFile *outFile, u64 progId);
 bool readSysmoduleCxiNcchHeader(Ncch *outNcchHeader, IFile *file);


### PR DESCRIPTION
If game patching is enabled, read a 16-bit value from luma/titles/<titleID>/remaster.bin. Set the game's remaster version to 0 if it is higher than this value. This forces a specific game update to be loaded, if it is present.

Closes #2159. 

I explained the rationale in the linked issue, but to summarize: it is possible for certain games that two copies can be the "most recent version" and nonetheless contain different binaries. I know for sure this affects Tomodachi Life, but it may be an issue for other games as well. 
With this feature, modders can target a single version of the game (the most recent downloadable update) that they know is legally accessible to all players.