### PR TITLE
plugin_loader: Make plugin reply timeout configurable

### DIFF
--- a/sysmodules/rosalina/include/plugin/plgldr.h
+++ b/sysmodules/rosalina/include/plugin/plgldr.h
@@ -56,10 +56,12 @@ typedef struct
     s32*            plgldrEvent; ///< Used for synchronization
     s32*            plgldrReply; ///< Used for synchronization
     u8              notifyHomeEvent;
-    u8              padding[3];
-    u32             reserved[23];
+    u8              padding[7];
+    u64             waitForReplyTimeout;
+    u32             reserved[20];
     u32             config[32];
-}   PluginHeader;
+} PluginHeader;
+_Static_assert(sizeof(PluginHeader) == 0x100, "Invalid PluginHeader size");
 
 typedef void (*OnPlgLdrEventCb_t)(s32 eventType);
 

--- a/sysmodules/rosalina/source/plugin/file_loader.c
+++ b/sysmodules/rosalina/source/plugin/file_loader.c
@@ -270,6 +270,7 @@ bool     TryToLoadPlugin(Handle process, bool isHomebrew)
     }
 
     pluginHeader->version = header->version;
+    pluginHeader->waitForReplyTimeout = 10000000000ULL;
     // Code size must be page aligned
     exeHdr = &header->executable;
     pluginHeader->exeSize = (sizeof(PluginHeader) + exeHdr->codeSize + exeHdr->rodataSize + exeHdr->dataSize + exeHdr->bssSize + 0x1000) & ~0xFFF;

--- a/sysmodules/rosalina/source/plugin/plgloader.c
+++ b/sysmodules/rosalina/source/plugin/plgloader.c
@@ -516,7 +516,7 @@ void    PLG__WaitForReply(void)
 {
     if (PluginLoaderCtx.eventsSelfManaged) return;
     __strex__(PluginLoaderCtx.plgReplyPA, PLG_WAIT);
-    svcArbitrateAddress(PluginLoaderCtx.arbiter, (u32)PluginLoaderCtx.plgReplyPA, ARBITRATION_WAIT_IF_LESS_THAN_TIMEOUT, PLG_OK, 10000000000ULL);
+    svcArbitrateAddress(PluginLoaderCtx.arbiter, (u32)PluginLoaderCtx.plgReplyPA, ARBITRATION_WAIT_IF_LESS_THAN_TIMEOUT, PLG_OK, MemoryBlock__GetMappedPluginHeader()->waitForReplyTimeout);
 }
 
 void     PLG__SetConfigMemoryStatus(u32 status)


### PR DESCRIPTION
Makes the plugin event reply timeout configurable by the current running plugin. If a plugin decides that it will take more than 10 seconds to handle an event, it will no longer cause a timeout.