### PR TITLE
loader: Support memory mode override configuration between hardware reboot

### DIFF
--- a/sysmodules/loader/source/loader.h
+++ b/sysmodules/loader/source/loader.h
@@ -2,4 +2,13 @@
 
 #include <3ds/types.h>
 
+// Used by the custom loader command 0x101 (ControlApplicationMemoryModeOverride)
+typedef struct ControlApplicationMemoryModeOverrideConfig {
+    u32 query : 1; //< Only query the current configuration, do not update it.
+    u32 enable_o3ds : 1; //< Enable o3ds memory mode override
+    u32 enable_n3ds : 1; //< Enable n3ds memory mode override
+    u32 o3ds_mode : 3; //< O3ds memory mode
+    u32 n3ds_mode : 3; //< N3ds memory mode
+} ControlApplicationMemoryModeOverrideConfig;
+
 void loaderHandleCommands(void *ctx);


### PR DESCRIPTION
The configuration is loaded from a file at startup and can be updated via custom command 0x101.
This provides a viable solution for issue #1862:
The NS module writes the content of cmdbuf[6] to offset 0x400 of the Firm Launch parameters so that the device can write it to 0x1FF80030 during boot.
However, when the NS module performs the auto-boot mechanism, it reads the target program’s exheader, compares the program’s memtype with the value at 0x1FF80030, and if they don’t match, the NS module will reboot again using the program’s memtype.
So we not only need to pass the expected appmemtype to the NS_RebootToTitle function, but also temporarily patch the exheader of the auto-boot target application. This way, when the NS module performs the comparison, we can “trick” it into launching the target application with our desired appmemtype. See also: https://github.com/devkitPro/libctru/pull/592