### PR TITLE
LayeredFS: Call UnMountArchive before Mount

### DIFF
--- a/sysmodules/loader/source/patcher.c
+++ b/sysmodules/loader/source/patcher.c
@@ -631,9 +631,9 @@ static inline bool patchLayeredFs(u64 progId, u8 *code, u32 size, u32 textSize, 
     romfsRedirPatchSubstituted2 = *(u32 *)(code + fsTryOpenFile);
     romfsRedirPatchHook2 = MAKE_BRANCH(payloadOffset + (u32)&romfsRedirPatchHook2 - (u32)romfsRedirPatch, fsTryOpenFile + 4);
     romfsRedirPatchCustomPath = pathAddress;
-    romfsRedirPatchFsMountArchive = 0x100000 + fsMountArchive;
-    romfsRedirPatchFsUnMountArchive = 0x100000 + fsUnMountArchive;
-    romfsRedirPatchFsRegisterArchive = 0x100000 + fsRegisterArchive;
+    romfsRedirPatchFsMountArchive = MAKE_BRANCH_LINK(payloadOffset + (u32)&romfsRedirPatchFsMountArchive - (u32)romfsRedirPatch, fsMountArchive);
+    romfsRedirPatchFsUnMountArchive = MAKE_BRANCH_LINK(payloadOffset + (u32)&romfsRedirPatchFsUnMountArchive - (u32)romfsRedirPatch, fsUnMountArchive);
+    romfsRedirPatchFsRegisterArchive = MAKE_BRANCH_LINK(payloadOffset + (u32)&romfsRedirPatchFsRegisterArchive - (u32)romfsRedirPatch, fsRegisterArchive);
     romfsRedirPatchArchiveId = archiveId;
     memcpy(&romfsRedirPatchUpdateRomFsMount, updateRomFsMount, 4);
 

--- a/sysmodules/loader/source/romfsredir.h
+++ b/sysmodules/loader/source/romfsredir.h
@@ -10,6 +10,7 @@ extern u32 romfsRedirPatchSubstituted2, romfsRedirPatchHook2;
 
 extern u32 romfsRedirPatchArchiveName;
 extern u32 romfsRedirPatchFsMountArchive;
+extern u32 romfsRedirPatchFsUnMountArchive;
 extern u32 romfsRedirPatchFsRegisterArchive;
 extern u32 romfsRedirPatchArchiveId;
 extern u32 romfsRedirPatchRomFsMount;

--- a/sysmodules/loader/source/romfsredir.s
+++ b/sysmodules/loader/source/romfsredir.s
@@ -30,6 +30,9 @@ romfsRedirPatch:
         cmp     r3, #3
         bne     romfsRedirPatchSubstituted1
         stmfd   sp!, {r0-r4, lr}
+        adr     r0, romfsRedirPatchArchiveName
+        ldr     r4, romfsRedirPatchFsUnMountArchive
+        blx     r4
         sub     sp, sp, #4
         ldr     r1, romfsRedirPatchArchiveId
         mov     r0, sp
@@ -109,6 +112,7 @@ romfsRedirPatch:
 
     .global romfsRedirPatchArchiveName
     .global romfsRedirPatchFsMountArchive
+    .global romfsRedirPatchFsUnMountArchive
     .global romfsRedirPatchFsRegisterArchive
     .global romfsRedirPatchArchiveId
     .global romfsRedirPatchRomFsMount
@@ -117,6 +121,7 @@ romfsRedirPatch:
 
     romfsRedirPatchArchiveName       : .ascii "lf:\0"
     romfsRedirPatchFsMountArchive    : .word 0xdead0005
+    romfsRedirPatchFsUnMountArchive  : .word 0xdead0009
     romfsRedirPatchFsRegisterArchive : .word 0xdead0006
     romfsRedirPatchArchiveId         : .word 0xdead0007
     romfsRedirPatchRomFsMount        : .ascii "rom:"

--- a/sysmodules/loader/source/romfsredir.s
+++ b/sysmodules/loader/source/romfsredir.s
@@ -31,19 +31,22 @@ romfsRedirPatch:
         bne     romfsRedirPatchSubstituted1
         stmfd   sp!, {r0-r4, lr}
         adr     r0, romfsRedirPatchArchiveName
-        ldr     r4, romfsRedirPatchFsUnMountArchive
-        blx     r4
+        .global romfsRedirPatchFsUnMountArchive
+        romfsRedirPatchFsUnMountArchive:
+            .word 0xdead0004
         sub     sp, sp, #4
         ldr     r1, romfsRedirPatchArchiveId
         mov     r0, sp
-        ldr     r4, romfsRedirPatchFsMountArchive
-        blx     r4
+        .global romfsRedirPatchFsMountArchive
+        romfsRedirPatchFsMountArchive:
+            .word 0xdead0005
         mov     r3, #0
         mov     r2, #0
         ldr     r1, [sp]
         adr     r0, romfsRedirPatchArchiveName
-        ldr     r4, romfsRedirPatchFsRegisterArchive
-        blx     r4
+        .global romfsRedirPatchFsRegisterArchive
+        romfsRedirPatchFsRegisterArchive:
+            .word 0xdead0006
         add     sp, sp, #4
         ldmfd   sp!, {r0-r4, lr}
         b       romfsRedirPatchSubstituted1
@@ -111,22 +114,16 @@ romfsRedirPatch:
 .balign 4
 
     .global romfsRedirPatchArchiveName
-    .global romfsRedirPatchFsMountArchive
-    .global romfsRedirPatchFsUnMountArchive
-    .global romfsRedirPatchFsRegisterArchive
     .global romfsRedirPatchArchiveId
     .global romfsRedirPatchRomFsMount
     .global romfsRedirPatchUpdateRomFsMount
     .global romfsRedirPatchCustomPath
 
     romfsRedirPatchArchiveName       : .ascii "lf:\0"
-    romfsRedirPatchFsMountArchive    : .word 0xdead0005
-    romfsRedirPatchFsUnMountArchive  : .word 0xdead0009
-    romfsRedirPatchFsRegisterArchive : .word 0xdead0006
     romfsRedirPatchArchiveId         : .word 0xdead0007
     romfsRedirPatchRomFsMount        : .ascii "rom:"
     romfsRedirPatchUpdateRomFsMount  : .word 0xdead0008
-    romfsRedirPatchCustomPath        : .word 0xdead0004
+    romfsRedirPatchCustomPath        : .word 0xdead0009
 
 _romfsRedirPatchEnd:
 


### PR DESCRIPTION
This prevents the archive handle from remaining unreleased after used, which could otherwise lead to memory overflows in certain situations. See also: [3ds-battery-patches#4](https://github.com/R-YaTian/3ds-battery-patches/issues/4)
Additionally, the `MAKE_BRANCH_LINK` macro is now used to generate BL jump instructions to `fsMountArchive`, `fsUnMountArchive`, and `fsRegisterArchive`. This saves a few bytes in the LFS patch code, preventing issues where the replacement of the `throwFatalError` function could exceed the original function size. The original LFS patch code used the BLX instruction, this is unnecessary because none of the three functions require switching to THUMB mode.
Edit: This PR also fix #1954.