### PR TITLE
rosalina: use persistent service handles and proper PM termination

### DIFF
--- a/sysmodules/rosalina/include/menu.h
+++ b/sysmodules/rosalina/include/menu.h
@@ -68,6 +68,7 @@ typedef struct Menu {
 extern u32 menuCombo;
 extern bool isHidInitialized;
 extern bool isQtmInitialized;
+extern bool isMcuHwcInitialized;
 extern u32 mcuFwVersion;
 extern u8 mcuInfoTable[10];
 extern bool mcuInfoTableRead;
@@ -95,6 +96,8 @@ MyThread *menuCreateThread(void);
 void    menuEnter(void);
 void    menuLeave(void);
 void    menuThreadMain(void);
+void    menuInitializeMcuHwc(void);
+void    menuCloseMcuHwc(void);
 void    menuShow(Menu *root);
 void    DispMessage(const char *title, const char *message);
 u32     DispErrMessage(const char *title, const char *message, const Result error);

--- a/sysmodules/rosalina/include/shell.h
+++ b/sysmodules/rosalina/include/shell.h
@@ -26,4 +26,8 @@
 
 #include <3ds/types.h>
 
+extern bool isCdcChkInitialized;
+
+void initAudioServiceHandle(void);
+void closeAudioServiceHandle(void);
 void handleShellOpened(void);


### PR DESCRIPTION
## Summary

This PR addresses two architectural improvements in Rosalina:

### 1. Stop Opening/Closing cdc:CHK and mcu::HWC Repeatedly

- Refactors `forceAudioOutput()` and similar functions to use persistent service handles
- Handles are initialized once at startup (following the existing QTM pattern)
- Eliminates thread spawn/despawn overhead in the codec/mcu sysmodules
- Adds proper cleanup in `handlePreTermNotification()`

### 2. Document PM Termination Behavior

- Adds documentation explaining why `svcExitProcess()` is used directly instead of `PMAPP_TerminateProcess()`
- Self-termination via PM would cause a deadlock (Rosalina waiting for PM call to return while PM waits for Rosalina to handle notification)
- Proper cleanup is already handled by `handlePreTermNotification()` when PM sends notification 0x2000 during system shutdown

### Files Changed

- **shell.c/h**: Add cdc:CHK handle management (`initAudioServiceHandle()`, `closeAudioServiceHandle()`)
- **menu.c/h**: Add mcu::HWC handle management (`menuInitializeMcuHwc()`, `menuCloseMcuHwc()`)
- **main.c**: Document termination behavior and add service cleanup in pre-termination handler
- **sysconfig.c**: Use persistent handles (remove per-call init/exit)