### PR TITLE
Fix Rosalina menu freeze caused by race condition with GSP/GPU

### DIFF
--- a/sysmodules/rosalina/source/menu.c
+++ b/sysmodules/rosalina/source/menu.c
@@ -403,13 +403,39 @@ void menuEnter(void)
     {
         menuCloseRequested = false;
         menuRefCount++;
-        svcKernelSetState(0x10000, 2 | 1);
+
+        // Phase 1: Freeze game/app threads to stop new GPU command submissions
+        svcKernelSetState(0x10000, 1);
         svcSleepThread(5 * 1000 * 100LL);
+
+        // Phase 2: Wait for GPU + GSP to fully drain. After the game
+        // is frozen, GSP may still have multiple queued commands in
+        // its FIFO to submit one-by-one to the GPU hardware. A single
+        // busy-wait can pass while GSP is between commands (GPU idle
+        // but next command not yet submitted). Loop until GPU stays
+        // idle after giving GSP time to process, confirming the FIFO
+        // is fully drained and all completion interrupts delivered.
+        for (int i = 0; i < 8; i++)
+        {
+            while((GPU_PSC0_CNT | GPU_PSC1_CNT | GPU_TRANSFER_CNT | GPU_CMDLIST_CNT) & 1);
+            svcSleepThread(2 * 1000 * 1000LL);
+            if (!((GPU_PSC0_CNT | GPU_PSC1_CNT | GPU_TRANSFER_CNT | GPU_CMDLIST_CNT) & 1))
+                break;
+        }
+        // Final margin for GSP to process the last completion interrupt
+        svcSleepThread(1 * 1000 * 1000LL);
+
+        // Phase 3: Now freeze GSP (no pending completions to lose)
+        svcKernelSetState(0x10000, 2);
+        svcSleepThread(5 * 1000 * 100LL);
+
         if (R_FAILED(Draw_AllocateFramebufferCache(FB_BOTTOM_SIZE)))
         {
             // Oops
             menuRefCount = 0;
-            svcKernelSetState(0x10000, 2 | 1);
+            svcKernelSetState(0x10000, 2);
+            svcSleepThread(5 * 1000 * 100LL);
+            svcKernelSetState(0x10000, 1);
             svcSleepThread(5 * 1000 * 100LL);
         }
         else
@@ -427,7 +453,12 @@ void menuLeave(void)
     {
         Draw_RestoreFramebuffer();
         Draw_FreeFramebufferCache();
-        svcKernelSetState(0x10000, 2 | 1);
+
+        // Unfreeze GSP first so it can process any pending hardware
+        // interrupts before game threads resume and read the queue
+        svcKernelSetState(0x10000, 2);
+        svcSleepThread(2 * 1000 * 1000LL);
+        svcKernelSetState(0x10000, 1);
     }
     Draw_Unlock();
 }


### PR DESCRIPTION
The Rosalina menu open/close used svcKernelSetState(0x10000, 2 | 1) to freeze both game threads and GSP simultaneously. 
This sometimes caused freezes because GSP could be mid-command when frozen. Any pending GPU completions were never delivered, leaving the game in a deadlocked state on resume, forcing the user to force shut down the system.

Changes (menu.c):

**menuEnter: Split the single atomic freeze into a 3-phase sequence:**

- freeze game threads first (flag 1) to stop new GPU command submissions
- busy-wait loop (up to 8 iterations) for GPU engines (PSC0, PSC1, Transfer, Cmdlist) to drain, with sleeps between checks to let GSP process its FIFO
- freeze GSP (flag 2) only after GPU is confirmed idle
- on framebuffer allocation failure also now uses the correct sequenced unfreeze

**menuLeave:**

- unfreeze GSP first with a 2ms delay so it can process any pending hardware interrupts before game threads resume and read the queue