### PR TITLE
Extend EmuNAND support to 1.X-2.X, as well as prototype 0.14.12

### DIFF
--- a/arm9/source/emunand.c
+++ b/arm9/source/emunand.c
@@ -138,6 +138,22 @@ static inline u32 getOldSdmmc(u32 *sdmmc, u32 firmVersion)
 {
     switch(firmVersion)
     {
+       	case 0: // 1.0.0
+            *sdmmc = 0x080CF61C;
+            break;
+        case 2: // 1.1.0
+            *sdmmc = 0x080CF67C;
+            break;
+        case 9: // 2.0.0
+            *sdmmc = 0x080D5394;
+            break;
+        case 0xB: // 2.1.0
+            *sdmmc = 0x080D5494;
+            break;
+            
+        case 0x10: // 0.14.12
+            *sdmmc = 0x080CF85C;
+            break;
         case 0x18:
             *sdmmc = 0x080D91D8;
             break;
@@ -186,6 +202,123 @@ static inline u32 patchNandRw(u8 *pos, u32 size, u32 hookAddr)
     readOffset[1] = writeOffset[1] = 0x47A0;
     ((u32 *)writeOffset)[1] = ((u32 *)readOffset)[1] = hookAddr;
 
+    return 0;
+}
+
+static inline u32 patch2xNandRw(u8 *pos, u32 size, u32 hookAddr, u32 cidHookAddr, u32 firmVersion) {
+    static const u8 rwPattern[] = { 0xAD, 0xB0, 0x05, 0x00, 0x36, 0x9F, 0x0C, 0x00 };
+    static const u8 nandStructPattern[] = { 0xF8, 0xB5, 0xFF, 0x21, 0x02, 0x31 };
+    static const u8 nandStructPattern20[] = { 0x38, 0xB5, 0xFF, 0x21, 0x02, 0x31 };
+    static const u8 cidPattern[] = { 0x04, 0x00, 0x00, 0x6A, 0x0D, 0xF0, 0x9E, 0xFF };
+    static const u8 cidPattern20[] = { 0x04, 0x00, 0x00, 0x6A, 0x0D, 0xF0, 0x04, 0xFF };
+    
+    u16 *readOffset = (u16 *)memsearch(pos, rwPattern, size, sizeof(rwPattern));
+    
+    if (!readOffset) return 1;
+    
+    u16 *writeOffset = (u16 *)memsearch(((u8*)readOffset) + sizeof(rwPattern), rwPattern, size, sizeof(rwPattern));
+    
+    if (!writeOffset) return 1;
+    
+    // rewire NAND struct to be SD instead
+    u8 *nandSdmmcSelectOffset = (u8 *)memsearch(pos, firmVersion == 9 ? nandStructPattern20 : nandStructPattern, size, sizeof(nandStructPattern));
+    if (!nandSdmmcSelectOffset) return 1;
+    nandSdmmcSelectOffset[4] = 1; // sdmc
+    
+    // make cid forcefully return the correct cid
+    u16 *cidOffset = (u16 *)memsearch(pos, firmVersion == 9 ? cidPattern20 : cidPattern, size, sizeof(cidPattern));
+    if (!cidOffset) return 1;
+    cidOffset[0] = 0x4C01; // ldr r4, [pc, #0] -> pc = insn + 8
+    cidOffset[1] = 0x47A0; // blx r4
+    cidOffset[2] = 0xBF00; // nop
+    *(u32 *)(&cidOffset[3]) = cidHookAddr + 1; /* because it's a thumb function */
+    
+    // r/w rewire
+    readOffset[0] = writeOffset[0] = 0x4C01; // ldr r4, [pc, #4]
+    readOffset[1] = writeOffset[1] = 0x47A0; // blx r4
+    readOffset[2] = writeOffset[2] = 0xBF00; // nop
+    *(u32 *)(&readOffset[3]) = *(u32 *)(&writeOffset[3]) = hookAddr;
+    
+    // Read the emmc cid into the place hook will copy it from
+    sdmmc_get_cid(1, emunandPatchNandCid);
+    
+    return 0;
+}
+
+static inline u32 patch1412NandRw(u8 *pos, u32 size, u32 hookAddr, u32 cidHookAddr) {
+    static const u8 rwPattern[] = { 0x0D, 0x00, 0x01, 0x00, 0xAF, 0xB0 };
+    static const u8 nandStructPattern[] = { 0xF8, 0xB5, 0xFF, 0x21, 0x02, 0x31 };
+    static const u8 cidPattern[] = { 0x04, 0x00, 0x00, 0x6A, 0x0A, 0xF0, 0x48, 0xFE };
+    
+    u16 *readOffset = (u16 *)memsearch(pos, rwPattern, size, sizeof(rwPattern));
+    
+    if (!readOffset) return 1;
+    
+    u16 *writeOffset = (u16 *)memsearch(((u8*)readOffset) + sizeof(rwPattern), rwPattern, size, sizeof(rwPattern));
+    
+    if (!writeOffset) return 1;
+    
+    // rewire NAND struct to be SD instead
+    u8 *nandSdmmcSelectOffset = (u8 *)memsearch(pos, nandStructPattern, size, sizeof(nandStructPattern));
+    if (!nandSdmmcSelectOffset) return 1;
+    nandSdmmcSelectOffset[4] = 1; // sdmc
+    
+    // make cid forcefully return the correct cid
+    u16 *cidOffset = (u16 *)memsearch(pos, cidPattern, size, sizeof(cidPattern));
+    if (!cidOffset) return 1;
+    cidOffset[0] = 0x4C01; // ldr r4, [pc, #0] -> pc = insn + 8
+    cidOffset[1] = 0x47A0; // blx r4
+    cidOffset[2] = 0xBF00; // nop
+    *(u32 *)(&cidOffset[3]) = cidHookAddr + 1; /* because it's a thumb function */
+    
+    // r/w rewire
+    readOffset[0] = writeOffset[0] = 0x4C01; // ldr r4, [pc, #4]
+    readOffset[1] = writeOffset[1] = 0x47A0; // blx r4
+    readOffset[2] = writeOffset[2] = 0xBF00; // nop
+    *(u32 *)(&readOffset[3]) = *(u32 *)(&writeOffset[3]) = hookAddr;
+    
+    // Read the emmc cid into the place hook will copy it from
+    sdmmc_get_cid(1, emunandPatchNandCid);
+    
+    return 0;
+}
+
+static inline u32 patch1xNandRw(u8 *pos, u32 size, u32 hookAddr, u32 cidHookAddr, u32 firmVersion)
+{
+    static const u8 rwPattern[] = { 0x0D, 0x00, 0x01, 0x00, 0xAF, 0xB0 };
+    static const u8 nandStructPattern[] = { 0xF8, 0xB5, 0xFF, 0x21, 0x02, 0x31 };
+    static const u8 cidPattern[] = { 0x04, 0x00, 0x00, 0x6A, 0x0A, 0xF0, 0x3D, 0xFE };
+    static const u8 cidPattern1_1_0_0[] = { 0x04, 0x00, 0x00, 0x6A, 0x0A, 0xF0, 0xA9, 0xFA };
+    
+    u16 *readOffset = (u16 *)memsearch(pos, rwPattern, size, sizeof(rwPattern));
+    
+    if (!readOffset) return 1;
+    
+    u16 *writeOffset = (u16 *)memsearch(((u8*)readOffset) + sizeof(rwPattern), rwPattern, size, sizeof(rwPattern));
+    
+    if (!writeOffset) return 1;
+    
+    // rewire NAND struct to be SD instead
+    u8 *nandSdmmcSelectOffset = (u8 *)memsearch(pos, nandStructPattern, size, sizeof(nandStructPattern));
+    if (!nandSdmmcSelectOffset) return 1;
+    nandSdmmcSelectOffset[4] = 1; // sdmc
+    
+    // make cid forcefully return the correct cid
+    u16 *cidOffset = (u16 *)memsearch(pos, firmVersion == 2 ? cidPattern1_1_0_0 : cidPattern, size, sizeof(cidPattern));
+    if (!cidOffset) return 1;
+    cidOffset[0] = 0x4C00;
+    cidOffset[1] = 0x47A0;
+    *(u32 *)(&cidOffset[2]) = cidHookAddr + 1; /* because it's a thumb function */
+    
+    // r/w rewire
+    readOffset[0] = writeOffset[0] = 0x4C01; // ldr r4, [pc, #4]
+    readOffset[1] = writeOffset[1] = 0x47A0; // blx r4
+    readOffset[2] = writeOffset[2] = 0xBF00; // nop
+    *(u32 *)(&readOffset[3]) = *(u32 *)(&writeOffset[3]) = hookAddr;
+    
+    // Read the emmc cid into the place hook will copy it from
+    sdmmc_get_cid(1, emunandPatchNandCid);
+    
     return 0;
 }
 
@@ -412,7 +545,24 @@ u32 patchEmuNand(u8 *process9Offset, u32 process9Size, u32 firmVersion)
     if(!ret) emunandPatchSdmmcStructPtr = sdmmc;
 
     //Add EmuNAND hooks
-    ret += patchNandRw(process9Offset, process9Size, (u32)emunandPatch);
+    if (firmVersion < 0xC) { /* 1.0-2.X */
+        switch (firmVersion) {
+        case 0: // 1.0.0
+        case 2: // 1.1.0-0
+            ret += patch1xNandRw(process9Offset, process9Size, (u32)emunand1xPatch, (u32)(firmVersion == 2 ? emunand11CidPatch : emunand10CidPatch), firmVersion);
+            break;
+        case 9: // 2.0.0
+        case 11: // 2.1.0
+            ret += patch2xNandRw(process9Offset, process9Size, (u32)emunand2xPatch, (u32)(firmVersion == 9 ? emunand20CidPatch : emunand21CidPatch), firmVersion);
+            break;
+        default:
+            error("EmuNANDs for NATIVE_FIRM version %d are currently not supported.\n", firmVersion);
+        }
+    } else if (firmVersion == 0x10) {
+        ret += patch1412NandRw(process9Offset, process9Size, (u32)emunand1xPatch, (u32)emunand1412CidPatch);
+    } else { /* >= 3.X */
+	    ret += patchNandRw(process9Offset, process9Size, (u32)emunandPatch);
+    }
 
     return ret;
 }

--- a/arm9/source/emunand_patch.s
+++ b/arm9/source/emunand_patch.s
@@ -47,6 +47,311 @@ emunandPatch:
 
 _emunandPatchEnd:
 
+.global emunand1xPatch
+emunand1xPatch:
+    ldr r4, emunandPatchSdmmcStructPtr
+    cmp r0, r4
+    beq out1x
+    
+    ldr r5, [r4, #4]
+    cmp r5, #0
+    moveq r4, r0
+    beq after_replace
+    ldr r4, emunandPatchSdmmcStructPtr
+after_replace:
+	mov r0, r4 @ replace this with SDMC
+	mov r4, r3 @ get sector to read
+	
+    cmp r4, #0 @ For GW compatibility, see if we're trying to read the ncsd header (sector 0)
+
+    ldr r5, emunandPatchNandOffset
+    add r4, r5 @ Add the offset to the NAND in the SD
+
+    ldreq r5, emunandPatchNcsdHeaderOffset
+    addeq r4, r5 @ If we're reading the ncsd header, add the offset of that sector
+
+    mov r3, r4 @ Store sector to read
+
+    out1x:
+        @ execute code that we skipped before
+        mov r5, r1
+        mov r1, r0
+        sub sp, sp, #0xBC
+        mov r4, r0
+        ldr r7, [sp, #0xE0]
+
+        @ Return 6 bytes after where we got called,
+        @ due to the offset of this function being stored there
+        mov r0, lr
+        add r0, #6
+        bx r0
+
+.pool
+
+.global emunand2xPatch
+emunand2xPatch:
+    ldr r4, emunandPatchSdmmcStructPtr
+    cmp r0, r4
+    beq out2x
+    
+    ldr r5, [r4, #4]
+    cmp r5, #0
+    moveq r4, r0
+    beq _2x_after_replace
+    ldr r4, emunandPatchSdmmcStructPtr
+_2x_after_replace:
+	mov r0, r4 @ replace this with SDMC
+	mov r4, r3 @ get sector to read
+	
+    cmp r4, #0 @ For GW compatibility, see if we're trying to read the ncsd header (sector 0)
+
+    ldr r5, emunandPatchNandOffset
+    add r4, r5 @ Add the offset to the NAND in the SD
+
+    ldreq r5, emunandPatchNcsdHeaderOffset
+    addeq r4, r5 @ If we're reading the ncsd header, add the offset of that sector
+
+    mov r3, r4 @ Store sector to read
+
+    out2x:
+        @ execute code that we skipped before
+        
+        sub sp, sp, #0xB4
+        mov r5, r0
+        ldr r7, [sp, #0xD8]
+        mov r4, r1
+        mov r6, r3
+
+        @ Return 6 bytes after where we got called,
+        @ due to the offset of this function being stored there
+        mov r0, lr
+        add r0, #6
+        bx r0
+
+.pool
+
+.thumb
+.align 2
+.global emunand10CidPatch
+emunand10CidPatch:
+    push {r4-r7}
+    mov r7, lr
+    @ If we're already trying to access the SD, return
+    ldr r4, emunandPatchSdmmcStructPtr
+    cmp r0, r4
+    beq _10_cid_return
+    
+    @ Trying to access nand, so copy the NAND cid into r1
+    adr r4, emunandPatchNandCid
+    ldr r2, [r4, #0]
+    ldr r3, [r4, #4]
+    ldr r5, [r4, #8]
+    ldr r6, [r4, #0xc]
+    str r2, [r1, #0]
+    str r3, [r1, #4]
+    str r5, [r1, #8]
+    str r6, [r1, #0xc]
+    @ And return from whence we came
+    mov r0, #0
+    pop {r4-r7}
+    pop {r4, pc}
+    
+    _10_cid_return:
+        @ Execute original code that got patched.
+        mov r4, r0
+        ldr r0, [r0, #0x20]
+        ldr r6, =#0x806C9CF
+        blx r6
+        cmp r0, #0
+        
+        add r7, #4
+        mov lr, r7
+        pop {r4-r7}
+        bx lr
+        
+    .pool
+
+.global emunand11CidPatch
+emunand11CidPatch:
+    push {r4-r7}
+    mov r7, lr
+    @ If we're already trying to access the SD, return
+    ldr r4, emunandPatchSdmmcStructPtr
+    cmp r0, r4
+    beq _11_cid_return
+    
+    @ Trying to access nand, so copy the NAND cid into r1
+    adr r4, emunandPatchNandCid
+    ldr r2, [r4, #0]
+    ldr r3, [r4, #4]
+    ldr r5, [r4, #8]
+    ldr r6, [r4, #0xc]
+    str r2, [r1, #0]
+    str r3, [r1, #4]
+    str r5, [r1, #8]
+    str r6, [r1, #0xc]
+    @ And return from whence we came
+    mov r0, #0
+    pop {r4-r7}
+    pop {r4, pc}
+    
+    _11_cid_return:
+        @ Execute original code that got patched.
+        mov r4, r0
+        ldr r0, [r0, #0x20]
+        ldr r6, =#0x806C9D3
+        blx r6
+        cmp r0, #0
+        
+        add r7, #4
+        mov lr, r7
+        pop {r4-r7}
+        bx lr
+        
+    .pool
+    
+.global emunand1412CidPatch
+emunand1412CidPatch:
+    push {r4-r7}
+    mov r7, lr
+    @ If we're already trying to access the SD, return
+    ldr r4, emunandPatchSdmmcStructPtr
+    cmp r0, r4
+    beq _1412_cid_return
+    
+    @ Trying to access nand, so copy the NAND cid into r1
+    adr r4, emunandPatchNandCid
+    ldr r2, [r4, #0]
+    ldr r3, [r4, #4]
+    ldr r5, [r4, #8]
+    ldr r6, [r4, #0xc]
+    str r2, [r1, #0]
+    str r3, [r1, #4]
+    str r5, [r1, #8]
+    str r6, [r1, #0xc]
+    @ And return from whence we came
+    mov r0, #0
+    pop {r4-r7}
+    pop {r4, pc}
+    
+    _1412_cid_return:
+        @ Execute original code that got patched.
+        mov r4, r0
+        ldr r0, [r0, #0x20]
+        ldr r6, =#0x806C7AB
+        blx r6
+        cmp r0, #0
+        beq _1412_jumpback2
+        
+        add r7, #6
+        b _1412_jumpback
+        
+        _1412_jumpback2:
+        ldr r7, =#0x8061B29
+        
+        _1412_jumpback:
+        
+        mov lr, r7
+        pop {r4-r7}
+        bx lr
+        
+    .pool
+    
+.global emunand20CidPatch
+emunand20CidPatch:
+    push {r4-r7}
+    mov r7, lr
+    @ If we're already trying to access the SD, return
+    ldr r4, emunandPatchSdmmcStructPtr
+    cmp r0, r4
+    beq _20_cid_return
+    
+    @ Trying to access nand, so copy the NAND cid into r1
+    adr r4, emunandPatchNandCid
+    ldr r2, [r4, #0]
+    ldr r3, [r4, #4]
+    ldr r5, [r4, #8]
+    ldr r6, [r4, #0xc]
+    str r2, [r1, #0]
+    str r3, [r1, #4]
+    str r5, [r1, #8]
+    str r6, [r1, #0xc]
+    @ And return from whence we came
+    mov r0, #0
+    pop {r4-r7}
+    pop {r4, pc}
+    
+    _20_cid_return:
+        @ Execute original code that got patched.
+        mov r4, r0
+        ldr r0, [r0, #0x20]
+        ldr r6, =#0x8074813
+        blx r6
+        cmp r0, #0
+        beq _20_jumpback2
+        
+        add r7, #6
+        b _20_jumpback
+        
+        _20_jumpback2:
+        ldr r7, =#0x8066A19
+        
+        _20_jumpback:
+        
+        mov lr, r7
+        pop {r4-r7}
+        bx lr
+        
+    .pool
+
+.global emunand21CidPatch
+emunand21CidPatch:
+    push {r4-r7}
+    mov r7, lr
+    @ If we're already trying to access the SD, return
+    ldr r4, emunandPatchSdmmcStructPtr
+    cmp r0, r4
+    beq _21_cid_return
+    
+    @ Trying to access nand, so copy the NAND cid into r1
+    adr r4, emunandPatchNandCid
+    ldr r2, [r4, #0]
+    ldr r3, [r4, #4]
+    ldr r5, [r4, #8]
+    ldr r6, [r4, #0xc]
+    str r2, [r1, #0]
+    str r3, [r1, #4]
+    str r5, [r1, #8]
+    str r6, [r1, #0xc]
+    @ And return from whence we came
+    mov r0, #0
+    pop {r4-r7}
+    pop {r4, pc}
+    
+    _21_cid_return:
+        @ Execute original code that got patched.
+        mov r4, r0
+        ldr r0, [r0, #0x20]
+        ldr r6, =#0x80748BF
+        blx r6
+        cmp r0, #0
+        beq _21_jumpback2
+
+        add r7, #6
+        b _21_jumpback
+        
+    _21_jumpback2:
+        ldr r7, =#0x8066991
+        
+    _21_jumpback:
+        mov lr, r7
+        pop {r4-r7}
+        bx lr
+        
+    .pool
+
+.arm
+.align 4
 .global emunandProtoPatch
 emunandProtoPatch:
     @ Save registers

--- a/arm9/source/firm.c
+++ b/arm9/source/firm.c
@@ -150,7 +150,7 @@ static inline u32 loadFirmFromStorage(FirmwareType firmType)
     return firmSize;
 }
 
-u32 loadNintendoFirm(FirmwareType *firmType, FirmwareSource nandType, bool loadFromStorage, bool isSafeMode)
+u32 loadNintendoFirm(FirmwareType *firmType, bool loadFromStorage, bool isSafeMode)
 {
     u32 firmVersion = 0xFFFFFFFF,
         firmSize;
@@ -208,7 +208,7 @@ u32 loadNintendoFirm(FirmwareType *firmType, FirmwareSource nandType, bool loadF
 
         if(isO3dsFirm && (*firmType == NATIVE_FIRM || *firmType == NATIVE_FIRM1X2X))
         {
-            __attribute__((aligned(4))) static const u8 hashes[7][0x20] = {
+            __attribute__((aligned(4))) static const u8 hashes[8][0x20] = {
                 {0xD7, 0x43, 0x0F, 0x27, 0x8D, 0xC9, 0x3F, 0x4C, 0x96, 0xB5, 0xA8, 0x91, 0x48, 0xDB, 0x08, 0x8A,
                  0x7E, 0x46, 0xB3, 0x95, 0x65, 0xA2, 0x05, 0xF1, 0xF2, 0x41, 0x21, 0xF1, 0x0C, 0x59, 0x6A, 0x9D},
                 {0x82, 0xCD, 0x41, 0x1E, 0x80, 0xF6, 0xEA, 0x8C, 0xA8, 0xDE, 0x4A, 0x27, 0x5D, 0xDF, 0xFD, 0xAE,
@@ -217,6 +217,8 @@ u32 loadNintendoFirm(FirmwareType *firmType, FirmwareSource nandType, bool loadF
                  0x8A, 0x00, 0xB6, 0xDD, 0x36, 0x89, 0xC0, 0xE2, 0xC9, 0xA9, 0x99, 0x62, 0x57, 0x5E, 0x6C, 0x23},
                 {0xD4, 0x91, 0xBC, 0x28, 0xFA, 0xBE, 0xC8, 0xF6, 0x80, 0xD2, 0x62, 0x51, 0xAF, 0x4B, 0x37, 0xBA,
                  0x69, 0x1B, 0x33, 0x8B, 0x51, 0xA0, 0x35, 0x35, 0xF0, 0x2C, 0x66, 0xA6, 0x3A, 0xFB, 0xD5, 0xE7},
+                {0x82, 0x01, 0x0B, 0x59, 0x86, 0xC5, 0x9E, 0x97, 0x26, 0x0D, 0x51, 0x86, 0xAE, 0x97, 0x3E, 0x54,
+                 0x69, 0x7A, 0x90, 0x1A, 0x9B, 0x5D, 0x58, 0x16, 0xDE, 0xB8, 0x9F, 0x86, 0xB2, 0xE0, 0xD3, 0xB1},
                 {0x39, 0x75, 0xB5, 0x28, 0x24, 0x5E, 0x8B, 0x56, 0xBC, 0x83, 0x79, 0x41, 0x09, 0x2C, 0x42, 0xE6,
                  0x26, 0xB6, 0x80, 0x59, 0xA5, 0x56, 0xF9, 0xF9, 0x6E, 0xF3, 0x63, 0x05, 0x58, 0xDF, 0x35, 0xEF},
                 {0x81, 0x9E, 0x71, 0x58, 0xE5, 0x44, 0x73, 0xF7, 0x48, 0x78, 0x7C, 0xEF, 0x5E, 0x30, 0xE2, 0x28,
@@ -256,12 +258,15 @@ u32 loadNintendoFirm(FirmwareType *firmType, FirmwareSource nandType, bool loadF
                     break;
                 // Release
                 case 4:
-                    firmVersion = 0x18;
+                    firmVersion = 0x10;
                     break;
                 case 5:
-                    firmVersion = 0x1D;
+                    firmVersion = 0x18;
                     break;
                 case 6:
+                    firmVersion = 0x1D;
+                    break;
+                case 7:
                     firmVersion = 0x1F;
                     break;
                 default:
@@ -275,9 +280,6 @@ u32 loadNintendoFirm(FirmwareType *firmType, FirmwareSource nandType, bool loadF
 
     if(!ISN3DS && *firmType == NATIVE_FIRM && firm->section[0].address == (u8 *)0x1FF80000)
     {
-        //We can't boot < 3.x EmuNANDs
-        if(nandType != FIRMWARE_SYSNAND) error("An old unsupported EmuNAND has been detected.\nLuma3DS is unable to boot it.");
-
         //If you want to use SAFE_FIRM on 1.0, use Luma from NAND & comment this line:
         if(isSafeMode) error("SAFE_MODE is not supported on 1.x/2.x FIRM.");
 
@@ -731,7 +733,7 @@ u32 patchAgbFirm(bool loadFromStorage, bool doUnitinfoPatch)
     return ret;
 }
 
-u32 patch1x2xNativeAndSafeFirm(void)
+u32 patch1x2xNativeAndSafeFirm(u32 firmVersion, FirmwareSource nandType)
 {
     u8 *arm9Section = (u8 *)firm + firm->section[2].offset;
 
@@ -757,6 +759,9 @@ u32 patch1x2xNativeAndSafeFirm(void)
     //Arm9 exception handlers
     ret += patchArm9ExceptionHandlersInstall(arm9Section, kernel9Size);
     ret += patchSvcBreak9(arm9Section, kernel9Size, (u32)firm->section[2].address);
+    
+    //Apply EmuNAND patches
+    if(nandType != FIRMWARE_SYSNAND) ret += patchEmuNand(process9Offset, process9Size, firmVersion);
 
     //Apply firmlaunch patches
     //Doesn't work here if Luma is on SD. If you want to use SAFE_FIRM on 1.0, use Luma from NAND & uncomment this line:

--- a/arm9/source/firm.h
+++ b/arm9/source/firm.h
@@ -29,11 +29,11 @@
 #include "types.h"
 #include "3dsheaders.h"
 
-u32 loadNintendoFirm(FirmwareType *firmType, FirmwareSource nandType, bool loadFromStorage, bool isSafeMode);
+u32 loadNintendoFirm(FirmwareType *firmType, bool loadFromStorage, bool isSafeMode);
 void loadHomebrewFirm(u32 pressed);
 u32 patchNativeFirm(u32 firmVersion, FirmwareSource nandType, bool loadFromStorage, bool isFirmProtEnabled, bool needToInitSd, bool doUnitinfoPatch);
 u32 patchTwlFirm(u32 firmVersion, bool loadFromStorage, bool doUnitinfoPatch);
 u32 patchAgbFirm(bool loadFromStorage, bool doUnitinfoPatch);
-u32 patch1x2xNativeAndSafeFirm(void);
+u32 patch1x2xNativeAndSafeFirm(u32 firmVersion, FirmwareSource nandType);
 u32 patchPrototypeNative(FirmwareSource nandType, bool doUnitinfoPatch);
 void launchFirm(int argc, char **argv);

--- a/arm9/source/large_patches.h
+++ b/arm9/source/large_patches.h
@@ -29,6 +29,13 @@
 #include "types.h"
 
 extern const u8 emunandPatch[];
+extern const u8 emunand1xPatch[];
+extern const u8 emunand10CidPatch[];
+extern const u8 emunand11CidPatch[];
+extern const u8 emunand1412CidPatch[];
+extern const u8 emunand2xPatch[];
+extern const u8 emunand20CidPatch[];
+extern const u8 emunand21CidPatch[];
 extern const u8 emunandProtoPatch[];
 extern const u8 emunandProtoCidPatch[];
 extern const u8 emunandProtoPatch238[];

--- a/arm9/source/main.c
+++ b/arm9/source/main.c
@@ -364,7 +364,7 @@ boot:
     }
 
     bool loadFromStorage = CONFIG(LOADEXTFIRMSANDMODULES);
-    u32 firmVersion = loadNintendoFirm(&firmType, nandType, loadFromStorage, isSafeMode);
+    u32 firmVersion = loadNintendoFirm(&firmType, loadFromStorage, isSafeMode);
 
     bool doUnitinfoPatch = CONFIG(PATCHUNITINFO);
     u32 res = 0;
@@ -384,7 +384,7 @@ boot:
         case SAFE_FIRM:
         case SYSUPDATER_FIRM:
         case NATIVE_FIRM1X2X:
-            res = patch1x2xNativeAndSafeFirm();
+            res = patch1x2xNativeAndSafeFirm(firmVersion, nandType);
             break;
         case NATIVE_PROTOTYPE:
             res = patchPrototypeNative(nandType, doUnitinfoPatch);


### PR DESCRIPTION
This also removes the "An old unsupported EmuNAND..." message. Unsupported versions <3.X and not covered by the current patch set will instead display an error message stating the version of the NATIVE_FIRM the user tried to boot in an EmuNAND is unsupported.