### PR TITLE
LayeredFS: Allow `patchLayeredFs` if `fsUnmountArchive` symbol doesn't exist

### DIFF
--- a/sysmodules/loader/source/patcher.c
+++ b/sysmodules/loader/source/patcher.c
@@ -148,7 +148,7 @@ static u32 findFunctionStart(u8 *code, u32 pos)
     return 0xFFFFFFFF;
 }
 
-static inline bool findLayeredFsSymbols(u8 *code, u32 size, u32 *fsMountArchive, u32 *fsRegisterArchive, u32 *fsTryOpenFile, u32 *fsOpenFileDirectly, u32 *fsUnMountArchive)
+static inline bool findLayeredFsSymbols(u8 *code, u32 size, u32 *fsMountArchive, u32 *fsRegisterArchive, u32 *fsTryOpenFile, u32 *fsOpenFileDirectly, u32 *fsUnmountArchive)
 {
     u32 found = 0,
         *temp = NULL;
@@ -166,10 +166,10 @@ static inline bool findLayeredFsSymbols(u8 *code, u32 size, u32 *fsMountArchive,
                 if(addr <= size - 16 && *fsMountArchive == 0xFFFFFFFF && addr32[1] == 0xE1A04000 && addr32[2] == 0xE59F60A8 && addr32[3] == 0xE3A0C001) temp = fsMountArchive;
                 break;
             case 0xE2844001:
-                if(addr <= size - 12 && *fsUnMountArchive == 0xFFFFFFFF && addr32[1] == 0xE3540020 && addr32[2] == 0x3AFFFFF0) temp = fsUnMountArchive;
+                if(addr <= size - 12 && *fsUnmountArchive == 0xFFFFFFFF && addr32[1] == 0xE3540020 && addr32[2] == 0x3AFFFFF0) temp = fsUnmountArchive;
                 break;
             case 0xE353003A:
-                if(addr <= size - 12 && *fsUnMountArchive == 0xFFFFFFFF && (addr32[1] & 0xFFFFFF0F) == 0x0A000009 && (addr32[2] & 0xFFFF0FF0) == 0xE1A00400) temp = fsUnMountArchive;
+                if(addr <= size - 12 && *fsUnmountArchive == 0xFFFFFFFF && (addr32[1] & 0xFFFFFF0F) == 0x0A000009 && (addr32[2] & 0xFFFF0FF0) == 0xE1A00400) temp = fsUnmountArchive;
                 break;
             case 0xE3500008:
                 if(addr <= size - 12 && *fsRegisterArchive == 0xFFFFFFFF && (addr32[1] & 0xFFF00FF0) == 0xE1800400 && (addr32[2] & 0xFFF00FF0) == 0xE1800FC0) temp = fsRegisterArchive;
@@ -196,7 +196,7 @@ static inline bool findLayeredFsSymbols(u8 *code, u32 size, u32 *fsMountArchive,
         }
     }
 
-    return (found == 5 || (found == 4 && *fsUnMountArchive == 0xFFFFFFFF));
+    return (found == 5 || (found == 4 && *fsUnmountArchive == 0xFFFFFFFF));
 }
 
 static inline bool findLayeredFsPayloadOffset(u8 *code, u32 size, u32 roSize, u32 dataSize, u32 roAddress, u32 dataAddress, u32 *payloadOffset, u32 *pathOffset, u32 *pathAddress)
@@ -575,7 +575,7 @@ static inline bool patchLayeredFs(u64 progId, u8 *code, u32 size, u32 textSize, 
     if(!archiveId) return true;
 
     u32 fsMountArchive = 0xFFFFFFFF,
-        fsUnMountArchive = 0xFFFFFFFF,
+        fsUnmountArchive = 0xFFFFFFFF,
         fsRegisterArchive = 0xFFFFFFFF,
         fsTryOpenFile = 0xFFFFFFFF,
         fsOpenFileDirectly = 0xFFFFFFFF,
@@ -583,7 +583,7 @@ static inline bool patchLayeredFs(u64 progId, u8 *code, u32 size, u32 textSize, 
         pathOffset = 0,
         pathAddress = 0xDEADCAFE;
 
-    if(!findLayeredFsSymbols(code, textSize, &fsMountArchive, &fsRegisterArchive, &fsTryOpenFile, &fsOpenFileDirectly, &fsUnMountArchive) ||
+    if(!findLayeredFsSymbols(code, textSize, &fsMountArchive, &fsRegisterArchive, &fsTryOpenFile, &fsOpenFileDirectly, &fsUnmountArchive) ||
        !findLayeredFsPayloadOffset(code, textSize, roSize, dataSize, roAddress, dataAddress, &payloadOffset, &pathOffset, &pathAddress)) return false;
 
     static const char *updateRomFsMounts[] = { "ro2:",
@@ -632,9 +632,9 @@ static inline bool patchLayeredFs(u64 progId, u8 *code, u32 size, u32 textSize, 
     romfsRedirPatchHook2 = MAKE_BRANCH(payloadOffset + (u32)&romfsRedirPatchHook2 - (u32)romfsRedirPatch, fsTryOpenFile + 4);
     romfsRedirPatchCustomPath = pathAddress;
     romfsRedirPatchFsMountArchive = MAKE_BRANCH_LINK(payloadOffset + (u32)&romfsRedirPatchFsMountArchive - (u32)romfsRedirPatch, fsMountArchive);
-    romfsRedirPatchFsUnMountArchive = (fsUnMountArchive != 0xFFFFFFFF) ?
-        MAKE_BRANCH_LINK(payloadOffset + (u32)&romfsRedirPatchFsUnMountArchive - (u32)romfsRedirPatch, fsUnMountArchive) :
-        0xE320F000; // NOP if fsUnMountArchive doesn't exist
+    romfsRedirPatchFsUnmountArchive = (fsUnmountArchive != 0xFFFFFFFF) ?
+        MAKE_BRANCH_LINK(payloadOffset + (u32)&romfsRedirPatchFsUnmountArchive - (u32)romfsRedirPatch, fsUnmountArchive) :
+        0xE320F000; // NOP if fsUnmountArchive doesn't exist
     romfsRedirPatchFsRegisterArchive = MAKE_BRANCH_LINK(payloadOffset + (u32)&romfsRedirPatchFsRegisterArchive - (u32)romfsRedirPatch, fsRegisterArchive);
     romfsRedirPatchArchiveId = archiveId;
     memcpy(&romfsRedirPatchUpdateRomFsMount, updateRomFsMount, 4);

--- a/sysmodules/loader/source/patcher.c
+++ b/sysmodules/loader/source/patcher.c
@@ -196,7 +196,7 @@ static inline bool findLayeredFsSymbols(u8 *code, u32 size, u32 *fsMountArchive,
         }
     }
 
-    return found == 5;
+    return (found == 5 || (found == 4 && *fsUnMountArchive == 0xFFFFFFFF));
 }
 
 static inline bool findLayeredFsPayloadOffset(u8 *code, u32 size, u32 roSize, u32 dataSize, u32 roAddress, u32 dataAddress, u32 *payloadOffset, u32 *pathOffset, u32 *pathAddress)
@@ -632,7 +632,9 @@ static inline bool patchLayeredFs(u64 progId, u8 *code, u32 size, u32 textSize, 
     romfsRedirPatchHook2 = MAKE_BRANCH(payloadOffset + (u32)&romfsRedirPatchHook2 - (u32)romfsRedirPatch, fsTryOpenFile + 4);
     romfsRedirPatchCustomPath = pathAddress;
     romfsRedirPatchFsMountArchive = MAKE_BRANCH_LINK(payloadOffset + (u32)&romfsRedirPatchFsMountArchive - (u32)romfsRedirPatch, fsMountArchive);
-    romfsRedirPatchFsUnMountArchive = MAKE_BRANCH_LINK(payloadOffset + (u32)&romfsRedirPatchFsUnMountArchive - (u32)romfsRedirPatch, fsUnMountArchive);
+    romfsRedirPatchFsUnMountArchive = (fsUnMountArchive != 0xFFFFFFFF) ?
+        MAKE_BRANCH_LINK(payloadOffset + (u32)&romfsRedirPatchFsUnMountArchive - (u32)romfsRedirPatch, fsUnMountArchive) :
+        0xE320F000; // NOP if fsUnMountArchive doesn't exist
     romfsRedirPatchFsRegisterArchive = MAKE_BRANCH_LINK(payloadOffset + (u32)&romfsRedirPatchFsRegisterArchive - (u32)romfsRedirPatch, fsRegisterArchive);
     romfsRedirPatchArchiveId = archiveId;
     memcpy(&romfsRedirPatchUpdateRomFsMount, updateRomFsMount, 4);

--- a/sysmodules/loader/source/romfsredir.h
+++ b/sysmodules/loader/source/romfsredir.h
@@ -10,7 +10,7 @@ extern u32 romfsRedirPatchSubstituted2, romfsRedirPatchHook2;
 
 extern u32 romfsRedirPatchArchiveName;
 extern u32 romfsRedirPatchFsMountArchive;
-extern u32 romfsRedirPatchFsUnMountArchive;
+extern u32 romfsRedirPatchFsUnmountArchive;
 extern u32 romfsRedirPatchFsRegisterArchive;
 extern u32 romfsRedirPatchArchiveId;
 extern u32 romfsRedirPatchRomFsMount;

--- a/sysmodules/loader/source/romfsredir.s
+++ b/sysmodules/loader/source/romfsredir.s
@@ -31,8 +31,8 @@ romfsRedirPatch:
         bne     romfsRedirPatchSubstituted1
         stmfd   sp!, {r0-r4, lr}
         adr     r0, romfsRedirPatchArchiveName
-        .global romfsRedirPatchFsUnMountArchive
-        romfsRedirPatchFsUnMountArchive:
+        .global romfsRedirPatchFsUnmountArchive
+        romfsRedirPatchFsUnmountArchive:
             .word 0xdead0004
         sub     sp, sp, #4
         ldr     r1, romfsRedirPatchArchiveId


### PR DESCRIPTION
Issue #2242 reported a rare case where a few official games (such as Metroid: Samus Returns) do not unmount any resources after mounting them (romfs, save, etc.), causing `fsUnmountArchive` to not be linked into their code section.
This PR introduces a solution: if the `fsUnmountArchive` symbol is not found, `patchLayeredFs` is still allowed, and the call to `fsUnmountArchive` is replaced with NOP.
Also, "UnMount" has been corrected to "Unmount".
Edit: This PR will fix #2242.