### PR TITLE
rosalina: add timelock — limit console use with PIN-gated unlock

### DIFF
--- a/sysmodules/rosalina/include/menu.h
+++ b/sysmodules/rosalina/include/menu.h
@@ -97,6 +97,7 @@ void    menuLeave(void);
 void    menuRequestClose(void);
 void    menuThreadMain(void);
 void    menuShow(Menu *root);
+void    menuResetSelectedItem(void);
 void    DispMessage(const char *title, const char *message);
 u32     DispErrMessage(const char *title, const char *message, const Result error);
 void    DisplayPluginMenu(u32   *cmdbuf);

--- a/sysmodules/rosalina/include/menus/timelock_config.h
+++ b/sysmodules/rosalina/include/menus/timelock_config.h
@@ -1,0 +1,57 @@
+/*
+*   This file is part of Luma3DS
+*   Copyright (C) 2016-2020 Aurora Wright, TuxSH
+*
+*   This program is free software: you can redistribute it and/or modify
+*   it under the terms of the GNU General Public License as published by
+*   the Free Software Foundation, either version 3 of the License, or
+*   (at your option) any later version.
+*
+*   This program is distributed in the hope that it will be useful,
+*   but WITHOUT ANY WARRANTY; without even the implied warranty of
+*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*   GNU General Public License for more details.
+*
+*   You should have received a copy of the GNU General Public License
+*   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*
+*   Additional Terms 7.b and 7.c of GPLv3 apply to this file:
+*       * Requiring preservation of specified reasonable legal notices or
+*         author attributions in that material or in the Appropriate Legal
+*         Notices displayed by works containing it.
+*       * Prohibiting misrepresentation of the origin of that material,
+*         or requiring that modified versions of such material be marked in
+*         reasonable ways as different from the original version.
+*/
+
+#pragma once
+
+#include "menu.h"
+#include "../timelock_shared_config.h"
+
+
+typedef enum
+{
+    TL_MENU_TOGGLE,
+    TL_MENU_DELAY,
+    TL_MENU_DAILY_TOGGLE,
+    TL_MENU_RESET_HOUR,
+} TIMELOCK_CONFIG_MENU;
+
+extern Menu timelockMenu;
+
+bool TimelockMenu_IsMenuLocked(void);
+bool TimelockMenu_IsMenuUnlocked(void);
+void TimelockMenu_LockMenu(void);
+void TimelockMenu_UnlockMenu(void);
+bool TimelockMenu_CheckPIN(char *enteredPIN);
+
+void TimelockMenu_LoadData(void);
+void TimelockMenu_UpdateAll(void);
+void TimelockMenu_UpdateStatus(TIMELOCK_CONFIG_MENU menuItem);
+void TimelockMenu_ToggleTimelock(void);
+void TimelockMenu_Delay(void);
+void TimelockMenu_PIN(void);
+void TimelockMenu_ToggleDailyReset(void);
+void TimelockMenu_ResetHour(void);
+void TimelockMenu_SaveSettings(void);

--- a/sysmodules/rosalina/include/sha256.h
+++ b/sysmodules/rosalina/include/sha256.h
@@ -1,0 +1,26 @@
+/*
+*   Minimal SHA-256 for the timelock subsystem.
+*   Public-domain reference implementation (FIPS 180-4).
+*/
+
+#pragma once
+
+#include <3ds/types.h>
+#include <stddef.h>
+
+#define SHA256_DIGEST_SIZE 32
+#define SHA256_BLOCK_SIZE  64
+
+typedef struct {
+    u32  state[8];
+    u64  bitlen;
+    u32  datalen;
+    u8   data[SHA256_BLOCK_SIZE];
+} sha256_ctx;
+
+void sha256_init(sha256_ctx *ctx);
+void sha256_update(sha256_ctx *ctx, const u8 *data, size_t len);
+void sha256_final(sha256_ctx *ctx, u8 hash[SHA256_DIGEST_SIZE]);
+
+// One-shot convenience.
+void sha256(const u8 *data, size_t len, u8 hash[SHA256_DIGEST_SIZE]);

--- a/sysmodules/rosalina/include/timelock.h
+++ b/sysmodules/rosalina/include/timelock.h
@@ -1,0 +1,73 @@
+/*
+*   This file is part of Luma3DS
+*   Copyright (C) 2016-2021 Aurora Wright, TuxSH
+*
+*   This program is free software: you can redistribute it and/or modify
+*   it under the terms of the GNU General Public License as published by
+*   the Free Software Foundation, either version 3 of the License, or
+*   (at your option) any later version.
+*
+*   This program is distributed in the hope that it will be useful,
+*   but WITHOUT ANY WARRANTY; without even the implied warranty of
+*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*   GNU General Public License for more details.
+*
+*   You should have received a copy of the GNU General Public License
+*   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*
+*   Additional Terms 7.b and 7.c of GPLv3 apply to this file:
+*       * Requiring preservation of specified reasonable legal notices or
+*         author attributions in that material or in the Appropriate Legal
+*         Notices displayed by works containing it.
+*       * Prohibiting misrepresentation of the origin of that material,
+*         or requiring that modified versions of such material be marked in
+*         reasonable ways as different from the original version.
+*/
+
+#pragma once
+
+#include <3ds/types.h>
+#include "MyThread.h"
+#include "timelock_shared_config.h"
+
+
+#define MINUTES_TO_CHECK    1
+#define HEARTBEAT_MINUTES   30   // persist elapsed at most this often during play
+#define MS_PER_DAY          (24LL * 60LL * 60LL * 1000LL)
+#define MS_PER_HOUR         (60LL * 60LL * 1000LL)
+
+#define CORE_APPLICATION  0
+#define CORE_SYSTEM       1
+
+
+// From main.c
+extern bool menuShouldExit;
+extern bool preTerminationRequested;
+extern Handle preTerminationEvent;
+
+
+MyThread *timelockCreateThread(void);
+void timelockThreadMain(void);
+void timelockEnter(void);
+void timelockLeave(void);
+void timelockShow(void);
+
+// Disk I/O
+void timelockLoadData(void);
+void timelockSaveData(void);            // persists the runtime instance (timelockData)
+void timelockFinalSaveOnShutdown(void); // called from main.c handlePreTermNotification
+
+// PIN / hashing
+void timelockHashPin(const char pin[PIN_LENGTH], const u8 salt[TIMELOCK_SALT_LEN], u8 outHash[TIMELOCK_HASH_LEN]);
+bool timelockVerifyPin(const char pin[PIN_LENGTH], const u8 storedHash[TIMELOCK_HASH_LEN], const u8 storedSalt[TIMELOCK_SALT_LEN]);
+void timelockGenerateSalt(u8 outSalt[TIMELOCK_SALT_LEN]);
+void timelockInitDefaults(timelockConfig *cfg);  // fresh config with new salt + default PIN
+
+// Per-day reset
+s64  timelockGetRtcMs(void);                              // RTC milliseconds since 2000-01-01 (0 on failure)
+s64  timelockComputeNextResetMs(s64 nowMs, u8 hourLocal); // next reset eligibility timestamp
+
+// Existing PIN input UI (lock screen)
+bool checkPIN(void);
+void resetEnteredPIN(void);
+void timelockInput(void);

--- a/sysmodules/rosalina/include/timelock_shared_config.h
+++ b/sysmodules/rosalina/include/timelock_shared_config.h
@@ -1,0 +1,54 @@
+/*   This paricular file is licensed under the following terms: */
+
+/*
+*   This software is provided 'as-is', without any express or implied warranty. In no event will the authors be held liable
+*   for any damages arising from the use of this software.
+*
+*   Permission is granted to anyone to use this software for any purpose, including commercial applications, and to alter it
+*   and redistribute it freely, subject to the following restrictions:
+*
+*    The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
+*    If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
+*
+*    Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
+*    This notice may not be removed or altered from any source distribution.
+*/
+
+#pragma once
+
+#include <3ds/types.h>
+
+#define PIN_LENGTH        4
+#define CONFIG_FILE_PATH  "/luma/timelock_config.bin"
+
+// Versioning: any config with a different magic/version is treated as
+// missing and re-created with defaults. Avoids any migration code while
+// the schema is still evolving.
+#define TIMELOCK_MAGIC    0x4B434C54u    // 'TLCK'
+#define TIMELOCK_VERSION  2u
+
+#define TIMELOCK_HASH_LEN 32             // SHA-256
+#define TIMELOCK_SALT_LEN 16             // per-install random salt
+
+// PIN is "0000" by default. Stored only as SHA-256(salt || pin); the
+// plaintext never lives in the config file.
+extern const char PIN_ZERO[PIN_LENGTH];
+
+typedef struct CTR_PACKED CTR_ALIGN(4) timelockConfig
+{
+    u32  magic;                          // TIMELOCK_MAGIC
+    u16  version;                        // TIMELOCK_VERSION
+    u16  minutes;                        // limit before lock fires
+    u16  elapsedMinutes;                 // current elapsed
+    bool isEnabled;
+    bool dailyResetEnabled;              // auto-reset elapsed every day at resetHourLocal
+    u8   resetHourLocal;                 // 0-23
+    u8   reserved0;
+    u8   pinHash[TIMELOCK_HASH_LEN];     // SHA-256(salt || pin)
+    u8   pinSalt[TIMELOCK_SALT_LEN];     // per-install random; generated once at init
+    s64  nextResetEligibleAtMs;          // RTC ms since 2000-01-01; only credit a daily reset when now >= this
+} timelockConfig;
+
+
+extern bool isRosalinaMenuOpened;
+extern bool isTimeLocked;

--- a/sysmodules/rosalina/source/main.c
+++ b/sysmodules/rosalina/source/main.c
@@ -27,6 +27,7 @@
 #include <3ds.h>
 #include "memory.h"
 #include "menu.h"
+#include "timelock.h"
 #include "service_manager.h"
 #include "errdisp.h"
 #include "utils.h"
@@ -37,6 +38,7 @@
 #include "menus/screen_filters.h"
 #include "menus/cheats.h"
 #include "menus/sysconfig.h"
+#include "menus/timelock_config.h"
 #include "input_redirection.h"
 #include "minisoc.h"
 #include "draw.h"
@@ -186,6 +188,10 @@ static void handlePreTermNotification(u32 notificationId)
     (void)notificationId;
     // Might be subject to a race condition, but heh.
 
+    // Persist timelock elapsed before shutdown so power-off doesn't grant
+    // free time. The runtime instance holds the live counter.
+    timelockFinalSaveOnShutdown();
+
     miniSocUnlockState(true);
 
     // Disable input redirection
@@ -265,11 +271,13 @@ int main(void)
     Cheat_SeedRng(svcGetSystemTick());
     ScreenFiltersMenu_LoadConfig();
     SysConfigMenu_LoadConfig();
+    TimelockMenu_LoadData();
 
     MyThread *menuThread = menuCreateThread();
     MyThread *taskRunnerThread = taskRunnerCreateThread();
     MyThread *errDispThread = errDispCreateThread();
     bootdiagCreateThread();
+    MyThread *timelockThread = timelockCreateThread();
 
     if (R_FAILED(ServiceManager_Run(services, notifications, NULL)))
         svcBreak(USERBREAK_PANIC);
@@ -280,6 +288,7 @@ int main(void)
 
     MyThread_Join(taskRunnerThread, -1LL);
     MyThread_Join(errDispThread, -1LL);
+    MyThread_Join(timelockThread, -1LL);
 
     return 0;
 }

--- a/sysmodules/rosalina/source/menu.c
+++ b/sysmodules/rosalina/source/menu.c
@@ -39,6 +39,7 @@
 #include "plugin.h"
 #include "menus/screen_filters.h"
 #include "shell.h"
+#include "timelock_shared_config.h"
 
 //#define ROSALINA_MENU_SELF_SCREENSHOT 1 // uncomment this to enable the feature
 
@@ -52,6 +53,9 @@ bool mcuInfoTableRead = false;
 const char *topScreenType = NULL;
 const char *bottomScreenType = NULL;
 bool areScreenTypesInitialized = false;
+
+bool needsResetSelectedItem = false;
+bool isRosalinaMenuOpened = false;
 
 // libctru redefinition:
 
@@ -339,6 +343,24 @@ u32 menuCountItems(const Menu *menu)
     return n;
 }
 
+static inline u32 menuAdvanceCursorWithVisibilityHandling(const Menu* menu, u32 pos, u32 numItems, s32 displ)
+{
+    u32 menuIter = 0;
+    u32 selectedItem = pos;
+
+    do
+    {
+        // If everything is hidden in the menu, we return index 0 to avoid an infinite loop
+        if (menuIter >= numItems)
+            return 0;
+
+        selectedItem = menuAdvanceCursor(selectedItem, numItems, displ);
+        menuIter++;
+    } while (menuItemIsHidden(&menu->items[selectedItem]));
+
+    return selectedItem;
+}
+
 MyThread *menuCreateThread(void)
 {
     if(R_FAILED(MyThread_Create(&menuThread, menuThreadMain, menuThreadStack, 0x3000, 52, CORE_SYSTEM)))
@@ -379,8 +401,10 @@ void menuThreadMain(void)
 
         u32 kHeld = scanHeldKeys();
 
-        if(((kHeld & menuCombo) == menuCombo) && !g_blockMenuOpen)
+        if(((kHeld & menuCombo) == menuCombo) && !g_blockMenuOpen && !isTimeLocked)
         {
+            isRosalinaMenuOpened = true;
+
             menuEnter();
             if(isN3DS) N3DSMenu_UpdateStatus();
             PluginLoader__UpdateMenu();
@@ -410,6 +434,7 @@ void menuEnter(void)
             // Oops
             menuRefCount = 0;
             svcKernelSetState(0x10000, 2 | 1);
+            isRosalinaMenuOpened = false;
             svcSleepThread(5 * 1000 * 100LL);
         }
         else
@@ -428,6 +453,8 @@ void menuLeave(void)
         Draw_RestoreFramebuffer();
         Draw_FreeFramebufferCache();
         svcKernelSetState(0x10000, 2 | 1);
+
+        isRosalinaMenuOpened = false;
     }
     Draw_Unlock();
 }
@@ -522,7 +549,7 @@ void menuShow(Menu *root)
 
     u32 numItems = menuCountItems(currentMenu);
     if (menuItemIsHidden(&currentMenu->items[selectedItem]))
-        selectedItem = menuAdvanceCursor(selectedItem, numItems, 1);
+        selectedItem = menuAdvanceCursorWithVisibilityHandling(currentMenu, selectedItem, numItems, 1);
 
     menuCloseRequested = false;
 
@@ -565,7 +592,10 @@ void menuShow(Menu *root)
                     previousSelectedItems[nbPreviousMenus] = selectedItem;
                     previousMenus[nbPreviousMenus++] = currentMenu;
                     currentMenu = currentMenu->items[selectedItem].menu;
+
                     selectedItem = 0;
+                    if (menuItemIsHidden(&currentMenu->items[selectedItem]))
+                        selectedItem = menuAdvanceCursorWithVisibilityHandling(currentMenu, selectedItem, numItems, 1);
                     break;
                 default:
                     __builtin_trap(); // oops
@@ -605,9 +635,26 @@ void menuShow(Menu *root)
             } while (menuItemIsHidden(&currentMenu->items[selectedItem])); // assume at least one item is visible
         }
 
+        if (needsResetSelectedItem)
+        {
+            selectedItem = 0;
+            if (menuItemIsHidden(&currentMenu->items[selectedItem]))
+            {
+                do {
+                    selectedItem = menuAdvanceCursor(selectedItem, numItems, 1);
+                } while (menuItemIsHidden(&currentMenu->items[selectedItem]));
+            }
+            needsResetSelectedItem = false;
+        }
+
         Draw_Lock();
         menuDraw(currentMenu, selectedItem);
         Draw_Unlock();
     }
     while(!menuShouldExit && !menuCloseRequested);
+}
+
+void menuResetSelectedItem(void)
+{
+    needsResetSelectedItem = true;
 }

--- a/sysmodules/rosalina/source/menus.c
+++ b/sysmodules/rosalina/source/menus.c
@@ -36,6 +36,7 @@
 #include "menus/sysconfig.h"
 #include "menus/screen_filters.h"
 #include "plugin.h"
+#include "menus/timelock_config.h"
 #include "ifile.h"
 #include "memory.h"
 #include "fmt.h"
@@ -54,6 +55,7 @@ Menu rosalinaMenu = {
         { "Debugger options...", MENU, .menu = &debuggerMenu },
         { "System configuration...", MENU, .menu = &sysconfigMenu },
         { "Miscellaneous options...", MENU, .menu = &miscellaneousMenu },
+        { "Timelock options...", MENU, .menu = &timelockMenu },
         { "Save settings", METHOD, .method = &RosalinaMenu_SaveSettings },
         { "Return To HOME Menu", METHOD, .method = &RosalinaMenu_ReturnToHomeMenu },
         { "Power off / reboot", METHOD, .method = &RosalinaMenu_PowerOffOrReboot },

--- a/sysmodules/rosalina/source/menus/timelock_config.c
+++ b/sysmodules/rosalina/source/menus/timelock_config.c
@@ -1,0 +1,375 @@
+/*
+*   This file is part of Luma3DS
+*   Copyright (C) 2016-2020 Aurora Wright, TuxSH
+*
+*   This program is free software: you can redistribute it and/or modify
+*   it under the terms of the GNU General Public License as published by
+*   the Free Software Foundation, either version 3 of the License, or
+*   (at your option) any later version.
+*
+*   This program is distributed in the hope that it will be useful,
+*   but WITHOUT ANY WARRANTY; without even the implied warranty of
+*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*   GNU General Public License for more details.
+*
+*   You should have received a copy of the GNU General Public License
+*   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*
+*   Additional Terms 7.b and 7.c of GPLv3 apply to this file:
+*       * Requiring preservation of specified reasonable legal notices or
+*         author attributions in that material or in the Appropriate Legal
+*         Notices displayed by works containing it.
+*       * Prohibiting misrepresentation of the origin of that material,
+*         or requiring that modified versions of such material be marked in
+*         reasonable ways as different from the original version.
+*/
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <3ds.h>
+#include "draw.h"
+#include "ifile.h"
+#include "timelock.h"
+#include "menus/timelock_config.h"
+
+
+timelockConfig timelockConfigData;
+
+bool isMenuLocked = true;
+char timelockMenuToggle[]     = "[_] Toggle timelock";
+char timelockMenuDelay[]      = "[__0m] Delay";
+char timelockMenuDailyToggle[]= "[_] Daily reset";
+char timelockMenuResetHour[]  = "[__h] Reset hour";
+
+Menu timelockMenu = {
+    "Timelock menu",
+    {
+        { "Unlock menu",            METHOD, .method = &TimelockMenu_UnlockMenu,        .visibility = &TimelockMenu_IsMenuLocked },
+        { timelockMenuToggle,       METHOD, .method = &TimelockMenu_ToggleTimelock,    .visibility = &TimelockMenu_IsMenuUnlocked },
+        { timelockMenuDelay,        METHOD, .method = &TimelockMenu_Delay,             .visibility = &TimelockMenu_IsMenuUnlocked },
+        { timelockMenuDailyToggle,  METHOD, .method = &TimelockMenu_ToggleDailyReset,  .visibility = &TimelockMenu_IsMenuUnlocked },
+        { timelockMenuResetHour,    METHOD, .method = &TimelockMenu_ResetHour,         .visibility = &TimelockMenu_IsMenuUnlocked },
+        { "Change PIN",             METHOD, .method = &TimelockMenu_PIN,               .visibility = &TimelockMenu_IsMenuUnlocked },
+        { "Save settings",          METHOD, .method = &TimelockMenu_SaveSettings,      .visibility = &TimelockMenu_IsMenuUnlocked },
+        { "Lock menu",              METHOD, .method = &TimelockMenu_LockMenu,          .visibility = &TimelockMenu_IsMenuUnlocked },
+        {},
+    }
+};
+
+bool TimelockMenu_IsMenuLocked(void)   { return  isMenuLocked; }
+bool TimelockMenu_IsMenuUnlocked(void) { return !isMenuLocked; }
+
+void TimelockMenu_LockMenu(void)
+{
+    isMenuLocked = true;
+    menuResetSelectedItem();
+}
+
+void TimelockMenu_UnlockMenu(void)
+{
+    Draw_Lock();
+    Draw_ClearFramebuffer();
+    Draw_FlushFramebuffer();
+    Draw_Unlock();
+
+    u8 pinIndex = 0;
+    char currentPin[PIN_LENGTH];
+    memcpy(currentPin, PIN_ZERO, PIN_LENGTH);
+
+    do {
+        Draw_Lock();
+        Draw_DrawString(10, 10, COLOR_TITLE, "Timelock menu");
+        Draw_DrawString(10, 30, COLOR_WHITE, "Enter the PIN and press A.");
+        for (int i = 0; i < PIN_LENGTH; i++) {
+            Draw_DrawCharacter(10 + (i * 10), 50, COLOR_WHITE, currentPin[i]);
+            Draw_DrawCharacter(10 + (i * 10), 60, COLOR_WHITE, (i == pinIndex ? '^' : ' '));
+        }
+        Draw_DrawString(10, 80, COLOR_WHITE, "Press B to go back.");
+        Draw_FlushFramebuffer();
+        Draw_Unlock();
+
+        const u32 kDown = waitInputWithTimeout(1000);
+
+        if (kDown & KEY_DLEFT)
+            pinIndex = (pinIndex == 0 ? (PIN_LENGTH - 1) : (pinIndex - 1));
+        if (kDown & KEY_DRIGHT)
+            pinIndex = (pinIndex == (PIN_LENGTH - 1) ? 0 : (pinIndex + 1));
+        if (kDown & KEY_DUP)
+            currentPin[pinIndex] = (currentPin[pinIndex] == '9' ? '0' : (currentPin[pinIndex] + 1));
+        if (kDown & KEY_DDOWN)
+            currentPin[pinIndex] = (currentPin[pinIndex] == '0' ? '9' : (currentPin[pinIndex] - 1));
+
+        if (kDown & KEY_A) {
+            if (TimelockMenu_CheckPIN(currentPin)) {
+                isMenuLocked = false;
+                break;
+            }
+        }
+        if (kDown & KEY_B)
+            break;
+    } while (!menuShouldExit);
+
+    menuResetSelectedItem();
+}
+
+bool TimelockMenu_CheckPIN(char *enteredPIN)
+{
+    return timelockVerifyPin(enteredPIN, timelockConfigData.pinHash, timelockConfigData.pinSalt);
+}
+
+void TimelockMenu_LoadData(void)
+{
+    IFile file;
+    Result res;
+    u64 bytesRead = 0;
+    timelockConfig tmp;
+    bool ok = false;
+
+    s64 out = 0;
+    if (R_FAILED(svcGetSystemInfo(&out, 0x10000, 0x203))) svcBreak(USERBREAK_ASSERT);
+    FS_ArchiveID archiveId = ((bool)out) ? ARCHIVE_SDMC : ARCHIVE_NAND_RW;
+
+    res = IFile_Open(&file, archiveId, fsMakePath(PATH_EMPTY, ""),
+                     fsMakePath(PATH_ASCII, CONFIG_FILE_PATH), FS_OPEN_READ);
+    if (R_SUCCEEDED(res))
+        res = IFile_Read(&file, &bytesRead, &tmp, sizeof(tmp));
+    IFile_Close(&file);
+
+    if (R_SUCCEEDED(res) && bytesRead == sizeof(tmp)
+        && tmp.magic == TIMELOCK_MAGIC && tmp.version == TIMELOCK_VERSION) {
+        timelockConfigData = tmp;
+        ok = true;
+    }
+
+    if (!ok)
+        timelockInitDefaults(&timelockConfigData);
+
+    TimelockMenu_UpdateAll();
+}
+
+void TimelockMenu_UpdateAll(void)
+{
+    TimelockMenu_UpdateStatus(TL_MENU_TOGGLE);
+    TimelockMenu_UpdateStatus(TL_MENU_DELAY);
+    TimelockMenu_UpdateStatus(TL_MENU_DAILY_TOGGLE);
+    TimelockMenu_UpdateStatus(TL_MENU_RESET_HOUR);
+}
+
+void TimelockMenu_UpdateStatus(TIMELOCK_CONFIG_MENU menuItem)
+{
+    switch (menuItem) {
+        case TL_MENU_TOGGLE:
+            timelockMenuToggle[1] = (timelockConfigData.isEnabled ? 'x' : ' ');
+            break;
+        case TL_MENU_DELAY: {
+            const u16 minutesHundreds = timelockConfigData.minutes / 100;
+            const u16 minutesTens     = (timelockConfigData.minutes - (minutesHundreds * 100)) / 10;
+            timelockMenuDelay[1] = '0' + minutesHundreds;
+            timelockMenuDelay[2] = '0' + minutesTens;
+            break;
+        }
+        case TL_MENU_DAILY_TOGGLE:
+            timelockMenuDailyToggle[1] = (timelockConfigData.dailyResetEnabled ? 'x' : ' ');
+            break;
+        case TL_MENU_RESET_HOUR: {
+            const u8 h = timelockConfigData.resetHourLocal;
+            timelockMenuResetHour[1] = '0' + (h / 10);
+            timelockMenuResetHour[2] = '0' + (h % 10);
+            break;
+        }
+    }
+}
+
+void TimelockMenu_ToggleTimelock(void)
+{
+    timelockConfigData.isEnabled = !timelockConfigData.isEnabled;
+    TimelockMenu_UpdateStatus(TL_MENU_TOGGLE);
+}
+
+void TimelockMenu_ToggleDailyReset(void)
+{
+    timelockConfigData.dailyResetEnabled = !timelockConfigData.dailyResetEnabled;
+    // Force re-arming on next runtime tick.
+    timelockConfigData.nextResetEligibleAtMs = 0;
+    TimelockMenu_UpdateStatus(TL_MENU_DAILY_TOGGLE);
+}
+
+void TimelockMenu_Delay(void)
+{
+    Draw_Lock();
+    Draw_ClearFramebuffer();
+    Draw_FlushFramebuffer();
+    Draw_Unlock();
+
+    char currentMinutesString[12] = "000 minutes";
+
+    u16 currentMinutes = timelockConfigData.minutes;
+    if (currentMinutes < 10) currentMinutes = 10;
+    {
+        const u16 h = currentMinutes / 100;
+        const u16 t = (currentMinutes - (h * 100)) / 10;
+        currentMinutesString[0] = '0' + h;
+        currentMinutesString[1] = '0' + t;
+    }
+
+    do {
+        Draw_Lock();
+        Draw_DrawString(10, 10, COLOR_TITLE, "Timelock delay menu");
+        Draw_DrawString(10, 30, COLOR_WHITE, "Press A to save the delay.");
+        Draw_DrawString(10, 50, COLOR_WHITE, currentMinutesString);
+        Draw_DrawString(10, 70, COLOR_WHITE, "Press B to go back.");
+        Draw_FlushFramebuffer();
+        Draw_Unlock();
+
+        const u32 kDown = waitInputWithTimeout(1000);
+
+        if (kDown & KEY_DUP) {
+            currentMinutes = (currentMinutes == 990 ? 10 : (currentMinutes + 10));
+        }
+        if (kDown & KEY_DDOWN) {
+            currentMinutes = (currentMinutes == 10 ? 990 : (currentMinutes - 10));
+        }
+        if (kDown & (KEY_DUP | KEY_DDOWN)) {
+            const u16 h = currentMinutes / 100;
+            const u16 t = (currentMinutes - (h * 100)) / 10;
+            currentMinutesString[0] = '0' + h;
+            currentMinutesString[1] = '0' + t;
+        }
+
+        if (kDown & KEY_A) {
+            timelockConfigData.minutes = currentMinutes;
+            TimelockMenu_UpdateStatus(TL_MENU_DELAY);
+            break;
+        }
+        if (kDown & KEY_B)
+            break;
+    } while (!menuShouldExit);
+}
+
+void TimelockMenu_ResetHour(void)
+{
+    Draw_Lock();
+    Draw_ClearFramebuffer();
+    Draw_FlushFramebuffer();
+    Draw_Unlock();
+
+    u8 hour = timelockConfigData.resetHourLocal;
+    if (hour > 23) hour = 0;
+    char hourStr[16] = "00:00 (RTC)";
+
+    do {
+        hourStr[0] = '0' + (hour / 10);
+        hourStr[1] = '0' + (hour % 10);
+
+        Draw_Lock();
+        Draw_DrawString(10, 10, COLOR_TITLE, "Daily reset hour");
+        Draw_DrawString(10, 30, COLOR_WHITE, "Press A to save.");
+        Draw_DrawString(10, 50, COLOR_WHITE, hourStr);
+        Draw_DrawString(10, 70, COLOR_WHITE, "Press B to go back.");
+        Draw_FlushFramebuffer();
+        Draw_Unlock();
+
+        const u32 kDown = waitInputWithTimeout(1000);
+
+        if (kDown & KEY_DUP)
+            hour = (hour == 23) ? 0 : (hour + 1);
+        if (kDown & KEY_DDOWN)
+            hour = (hour == 0) ? 23 : (hour - 1);
+
+        if (kDown & KEY_A) {
+            timelockConfigData.resetHourLocal = hour;
+            timelockConfigData.nextResetEligibleAtMs = 0;  // re-arm on next tick
+            TimelockMenu_UpdateStatus(TL_MENU_RESET_HOUR);
+            break;
+        }
+        if (kDown & KEY_B)
+            break;
+    } while (!menuShouldExit);
+}
+
+void TimelockMenu_PIN(void)
+{
+    Draw_Lock();
+    Draw_ClearFramebuffer();
+    Draw_FlushFramebuffer();
+    Draw_Unlock();
+
+    u8 pinIndex = 0;
+    char currentPin[PIN_LENGTH];
+    memcpy(currentPin, PIN_ZERO, PIN_LENGTH);   // start fresh (no plaintext to display)
+
+    do {
+        Draw_Lock();
+        Draw_DrawString(10, 10, COLOR_TITLE, "Timelock PIN menu");
+        Draw_DrawString(10, 30, COLOR_WHITE, "Press A to save the new PIN.");
+        for (int i = 0; i < PIN_LENGTH; i++) {
+            Draw_DrawCharacter(10 + (i * 10), 50, COLOR_WHITE, currentPin[i]);
+            Draw_DrawCharacter(10 + (i * 10), 60, COLOR_WHITE, (i == pinIndex ? '^' : ' '));
+        }
+        Draw_DrawString(10, 80, COLOR_WHITE, "Press B to go back.");
+        Draw_FlushFramebuffer();
+        Draw_Unlock();
+
+        const u32 kDown = waitInputWithTimeout(1000);
+
+        if (kDown & KEY_DLEFT)
+            pinIndex = (pinIndex == 0 ? (PIN_LENGTH - 1) : (pinIndex - 1));
+        if (kDown & KEY_DRIGHT)
+            pinIndex = (pinIndex == (PIN_LENGTH - 1) ? 0 : (pinIndex + 1));
+        if (kDown & KEY_DUP)
+            currentPin[pinIndex] = (currentPin[pinIndex] == '9' ? '0' : (currentPin[pinIndex] + 1));
+        if (kDown & KEY_DDOWN)
+            currentPin[pinIndex] = (currentPin[pinIndex] == '0' ? '9' : (currentPin[pinIndex] - 1));
+
+        if (kDown & KEY_A) {
+            // Hash against the existing salt (salt persists across PIN changes).
+            timelockHashPin(currentPin, timelockConfigData.pinSalt, timelockConfigData.pinHash);
+            break;
+        }
+        if (kDown & KEY_B)
+            break;
+    } while (!menuShouldExit);
+}
+
+void TimelockMenu_SaveSettings(void)
+{
+    Result res;
+    IFile file;
+    u64 written = 0;
+    s64 out = 0;
+
+    timelockConfigData.elapsedMinutes = 0;  // user-initiated save resets elapsed
+
+    if (R_FAILED(svcGetSystemInfo(&out, 0x10000, 0x203))) svcBreak(USERBREAK_ASSERT);
+    FS_ArchiveID archiveId = ((bool)out) ? ARCHIVE_SDMC : ARCHIVE_NAND_RW;
+
+    res = IFile_Open(&file, archiveId, fsMakePath(PATH_EMPTY, ""),
+                     fsMakePath(PATH_ASCII, CONFIG_FILE_PATH), FS_OPEN_CREATE | FS_OPEN_WRITE);
+    if (R_SUCCEEDED(res))
+        res = IFile_SetSize(&file, sizeof(timelockConfigData));
+    if (R_SUCCEEDED(res))
+        res = IFile_Write(&file, &written, &timelockConfigData, sizeof(timelockConfigData), 0);
+    IFile_Close(&file);
+
+    Draw_Lock();
+    Draw_ClearFramebuffer();
+    Draw_FlushFramebuffer();
+    Draw_Unlock();
+
+    do {
+        Draw_Lock();
+        Draw_DrawString(10, 10, COLOR_TITLE, "Timelock options menu");
+        if (R_SUCCEEDED(res)) {
+            Draw_DrawString(10, 30, COLOR_WHITE, "Operation succeeded.");
+            Draw_DrawString(10, 50, COLOR_RED,   "The console needs to be rebooted");
+            Draw_DrawString(10, 60, COLOR_RED,   "in order to apply the changes.");
+        } else {
+            Draw_DrawFormattedString(10, 30, COLOR_WHITE, "Operation failed (0x%08lx).", res);
+        }
+        Draw_DrawString(10, 80, COLOR_WHITE, "Press B to go back.");
+        Draw_FlushFramebuffer();
+        Draw_Unlock();
+    } while (!(waitInput() & KEY_B) && !menuShouldExit);
+}

--- a/sysmodules/rosalina/source/sha256.c
+++ b/sysmodules/rosalina/source/sha256.c
@@ -1,0 +1,103 @@
+/*
+*   Minimal SHA-256 (FIPS 180-4). Public domain.
+*   Used by the timelock subsystem to hash PIN+salt for storage.
+*/
+
+#include "sha256.h"
+#include <string.h>
+
+#define ROTR(x, n) (((x) >> (n)) | ((x) << (32 - (n))))
+#define CH(x, y, z)  (((x) & (y)) ^ (~(x) & (z)))
+#define MAJ(x, y, z) (((x) & (y)) ^ ((x) & (z)) ^ ((y) & (z)))
+#define BSIG0(x) (ROTR((x),  2) ^ ROTR((x), 13) ^ ROTR((x), 22))
+#define BSIG1(x) (ROTR((x),  6) ^ ROTR((x), 11) ^ ROTR((x), 25))
+#define SSIG0(x) (ROTR((x),  7) ^ ROTR((x), 18) ^ ((x) >>  3))
+#define SSIG1(x) (ROTR((x), 17) ^ ROTR((x), 19) ^ ((x) >> 10))
+
+static const u32 K[64] = {
+    0x428a2f98u, 0x71374491u, 0xb5c0fbcfu, 0xe9b5dba5u, 0x3956c25bu, 0x59f111f1u, 0x923f82a4u, 0xab1c5ed5u,
+    0xd807aa98u, 0x12835b01u, 0x243185beu, 0x550c7dc3u, 0x72be5d74u, 0x80deb1feu, 0x9bdc06a7u, 0xc19bf174u,
+    0xe49b69c1u, 0xefbe4786u, 0x0fc19dc6u, 0x240ca1ccu, 0x2de92c6fu, 0x4a7484aau, 0x5cb0a9dcu, 0x76f988dau,
+    0x983e5152u, 0xa831c66du, 0xb00327c8u, 0xbf597fc7u, 0xc6e00bf3u, 0xd5a79147u, 0x06ca6351u, 0x14292967u,
+    0x27b70a85u, 0x2e1b2138u, 0x4d2c6dfcu, 0x53380d13u, 0x650a7354u, 0x766a0abbu, 0x81c2c92eu, 0x92722c85u,
+    0xa2bfe8a1u, 0xa81a664bu, 0xc24b8b70u, 0xc76c51a3u, 0xd192e819u, 0xd6990624u, 0xf40e3585u, 0x106aa070u,
+    0x19a4c116u, 0x1e376c08u, 0x2748774cu, 0x34b0bcb5u, 0x391c0cb3u, 0x4ed8aa4au, 0x5b9cca4fu, 0x682e6ff3u,
+    0x748f82eeu, 0x78a5636fu, 0x84c87814u, 0x8cc70208u, 0x90befffau, 0xa4506cebu, 0xbef9a3f7u, 0xc67178f2u,
+};
+
+static void sha256_transform(sha256_ctx *ctx, const u8 block[SHA256_BLOCK_SIZE])
+{
+    u32 w[64];
+    for (int i = 0, j = 0; i < 16; ++i, j += 4)
+        w[i] = ((u32)block[j] << 24) | ((u32)block[j+1] << 16) | ((u32)block[j+2] << 8) | (u32)block[j+3];
+    for (int i = 16; i < 64; ++i)
+        w[i] = SSIG1(w[i-2]) + w[i-7] + SSIG0(w[i-15]) + w[i-16];
+
+    u32 a = ctx->state[0], b = ctx->state[1], c = ctx->state[2], d = ctx->state[3];
+    u32 e = ctx->state[4], f = ctx->state[5], g = ctx->state[6], h = ctx->state[7];
+
+    for (int i = 0; i < 64; ++i) {
+        u32 t1 = h + BSIG1(e) + CH(e, f, g) + K[i] + w[i];
+        u32 t2 = BSIG0(a) + MAJ(a, b, c);
+        h = g; g = f; f = e; e = d + t1;
+        d = c; c = b; b = a; a = t1 + t2;
+    }
+
+    ctx->state[0] += a; ctx->state[1] += b; ctx->state[2] += c; ctx->state[3] += d;
+    ctx->state[4] += e; ctx->state[5] += f; ctx->state[6] += g; ctx->state[7] += h;
+}
+
+void sha256_init(sha256_ctx *ctx)
+{
+    ctx->bitlen  = 0;
+    ctx->datalen = 0;
+    ctx->state[0] = 0x6a09e667u; ctx->state[1] = 0xbb67ae85u;
+    ctx->state[2] = 0x3c6ef372u; ctx->state[3] = 0xa54ff53au;
+    ctx->state[4] = 0x510e527fu; ctx->state[5] = 0x9b05688cu;
+    ctx->state[6] = 0x1f83d9abu; ctx->state[7] = 0x5be0cd19u;
+}
+
+void sha256_update(sha256_ctx *ctx, const u8 *data, size_t len)
+{
+    for (size_t i = 0; i < len; ++i) {
+        ctx->data[ctx->datalen++] = data[i];
+        if (ctx->datalen == SHA256_BLOCK_SIZE) {
+            sha256_transform(ctx, ctx->data);
+            ctx->bitlen += 512;
+            ctx->datalen = 0;
+        }
+    }
+}
+
+void sha256_final(sha256_ctx *ctx, u8 hash[SHA256_DIGEST_SIZE])
+{
+    u32 i = ctx->datalen;
+    ctx->data[i++] = 0x80;
+
+    if (i > 56) {
+        while (i < SHA256_BLOCK_SIZE) ctx->data[i++] = 0;
+        sha256_transform(ctx, ctx->data);
+        i = 0;
+    }
+    while (i < 56) ctx->data[i++] = 0;
+
+    ctx->bitlen += (u64)ctx->datalen * 8u;
+    for (int j = 7; j >= 0; --j)
+        ctx->data[56 + (7 - j)] = (u8)((ctx->bitlen >> (j * 8)) & 0xff);
+    sha256_transform(ctx, ctx->data);
+
+    for (int j = 0; j < 8; ++j) {
+        hash[4*j + 0] = (u8)((ctx->state[j] >> 24) & 0xff);
+        hash[4*j + 1] = (u8)((ctx->state[j] >> 16) & 0xff);
+        hash[4*j + 2] = (u8)((ctx->state[j] >>  8) & 0xff);
+        hash[4*j + 3] = (u8)( ctx->state[j]        & 0xff);
+    }
+}
+
+void sha256(const u8 *data, size_t len, u8 hash[SHA256_DIGEST_SIZE])
+{
+    sha256_ctx ctx;
+    sha256_init(&ctx);
+    sha256_update(&ctx, data, len);
+    sha256_final(&ctx, hash);
+}

--- a/sysmodules/rosalina/source/timelock.c
+++ b/sysmodules/rosalina/source/timelock.c
@@ -1,0 +1,371 @@
+/*
+*   This file is part of Luma3DS
+*   Copyright (C) 2016-2021 Aurora Wright, TuxSH
+*
+*   This program is free software: you can redistribute it and/or modify
+*   it under the terms of the GNU General Public License as published by
+*   the Free Software Foundation, either version 3 of the License, or
+*   (at your option) any later version.
+*
+*   This program is distributed in the hope that it will be useful,
+*   but WITHOUT ANY WARRANTY; without even the implied warranty of
+*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*   GNU General Public License for more details.
+*
+*   You should have received a copy of the GNU General Public License
+*   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*
+*   Additional Terms 7.b and 7.c of GPLv3 apply to this file:
+*       * Requiring preservation of specified reasonable legal notices or
+*         author attributions in that material or in the Appropriate Legal
+*         Notices displayed by works containing it.
+*       * Prohibiting misrepresentation of the origin of that material,
+*         or requiring that modified versions of such material be marked in
+*         reasonable ways as different from the original version.
+*/
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <3ds.h>
+#include "draw.h"
+#include "ifile.h"
+#include "timelock.h"
+#include "sha256.h"
+
+
+static MyThread timelockThread;
+static u8 CTR_ALIGN(8) timelockThreadStack[0x1000];
+
+timelockConfig timelockData;
+const char PIN_ZERO[PIN_LENGTH] = {'0', '0', '0', '0'};
+
+bool isTimeLocked = false;
+int pinIndex = 0;
+char enteredPIN[PIN_LENGTH] = {0};
+
+
+MyThread *timelockCreateThread(void)
+{
+    if (R_FAILED(MyThread_Create(&timelockThread, timelockThreadMain, timelockThreadStack, 0x1000, 52, CORE_SYSTEM)))
+        svcBreak(USERBREAK_PANIC);
+
+    return &timelockThread;
+}
+
+// ---- hashing / salt ---------------------------------------------------------
+
+void timelockHashPin(const char pin[PIN_LENGTH], const u8 salt[TIMELOCK_SALT_LEN], u8 outHash[TIMELOCK_HASH_LEN])
+{
+    u8 buf[TIMELOCK_SALT_LEN + PIN_LENGTH];
+    memcpy(buf, salt, TIMELOCK_SALT_LEN);
+    memcpy(buf + TIMELOCK_SALT_LEN, pin, PIN_LENGTH);
+    sha256(buf, sizeof(buf), outHash);
+}
+
+bool timelockVerifyPin(const char pin[PIN_LENGTH], const u8 storedHash[TIMELOCK_HASH_LEN], const u8 storedSalt[TIMELOCK_SALT_LEN])
+{
+    u8 candidate[TIMELOCK_HASH_LEN];
+    timelockHashPin(pin, storedSalt, candidate);
+
+    // Constant-time compare to avoid leaking position via timing on the menu thread.
+    u8 diff = 0;
+    for (int i = 0; i < TIMELOCK_HASH_LEN; ++i)
+        diff |= candidate[i] ^ storedHash[i];
+    return diff == 0;
+}
+
+void timelockGenerateSalt(u8 outSalt[TIMELOCK_SALT_LEN])
+{
+    // Prefer the hardware PRNG via the PS service. Fall back to a
+    // tick-driven LCG if PS is unavailable — quality is fine for a
+    // per-install salt (not a key).
+    if (R_SUCCEEDED(psInit())) {
+        Result r = PS_GenerateRandomBytes(outSalt, TIMELOCK_SALT_LEN);
+        psExit();
+        if (R_SUCCEEDED(r))
+            return;
+    }
+
+    u64 seed = svcGetSystemTick();
+    for (int i = 0; i < TIMELOCK_SALT_LEN; ++i) {
+        seed = seed * 6364136223846793005ULL + 1442695040888963407ULL;
+        outSalt[i] = (u8)(seed >> 33);
+        seed ^= svcGetSystemTick();
+    }
+}
+
+void timelockInitDefaults(timelockConfig *cfg)
+{
+    memset(cfg, 0, sizeof(*cfg));
+    cfg->magic              = TIMELOCK_MAGIC;
+    cfg->version            = TIMELOCK_VERSION;
+    cfg->minutes            = 60;
+    cfg->elapsedMinutes     = 0;
+    cfg->isEnabled          = false;
+    cfg->dailyResetEnabled  = false;
+    cfg->resetHourLocal     = 0;
+    timelockGenerateSalt(cfg->pinSalt);
+    timelockHashPin(PIN_ZERO, cfg->pinSalt, cfg->pinHash);
+    cfg->nextResetEligibleAtMs = 0;  // first tick will arm it if dailyResetEnabled is later turned on
+}
+
+// ---- RTC --------------------------------------------------------------------
+
+s64 timelockGetRtcMs(void)
+{
+    s64 ms = 0;
+    if (R_FAILED(ptmSysmInit()))
+        return 0;
+    Result r = PTMSYSM_GetRtcTime(&ms);
+    ptmSysmExit();
+    return R_SUCCEEDED(r) ? ms : 0;
+}
+
+s64 timelockComputeNextResetMs(s64 nowMs, u8 hourLocal)
+{
+    if (nowMs <= 0)
+        return 0;
+    s64 dayStart = (nowMs / MS_PER_DAY) * MS_PER_DAY;
+    s64 todaysReset = dayStart + ((s64)hourLocal) * MS_PER_HOUR;
+    return (nowMs < todaysReset) ? todaysReset : (todaysReset + MS_PER_DAY);
+}
+
+// ---- file I/O ---------------------------------------------------------------
+
+static FS_ArchiveID timelockArchive(void)
+{
+    s64 out = 0;
+    if (R_FAILED(svcGetSystemInfo(&out, 0x10000, 0x203)))
+        svcBreak(USERBREAK_ASSERT);
+    return ((bool)out) ? ARCHIVE_SDMC : ARCHIVE_NAND_RW;
+}
+
+void timelockLoadData(void)
+{
+    IFile file;
+    Result res;
+    u64 bytesRead = 0;
+    timelockConfig tmp;
+    bool ok = false;
+
+    res = IFile_Open(&file, timelockArchive(), fsMakePath(PATH_EMPTY, ""),
+                     fsMakePath(PATH_ASCII, CONFIG_FILE_PATH), FS_OPEN_READ);
+    if (R_SUCCEEDED(res))
+        res = IFile_Read(&file, &bytesRead, &tmp, sizeof(tmp));
+    IFile_Close(&file);
+
+    if (R_SUCCEEDED(res) && bytesRead == sizeof(tmp)
+        && tmp.magic == TIMELOCK_MAGIC && tmp.version == TIMELOCK_VERSION) {
+        timelockData = tmp;
+        ok = true;
+    }
+
+    if (!ok) {
+        // First boot, missing file, or schema mismatch — start fresh.
+        // (Old plaintext-PIN files from valx76's build will not match
+        // magic/version and get replaced. Default PIN reverts to 0000.)
+        timelockInitDefaults(&timelockData);
+        timelockSaveData();
+    }
+}
+
+void timelockSaveData(void)
+{
+    IFile file;
+    Result res;
+    u64 written = 0;
+
+    res = IFile_Open(&file, timelockArchive(), fsMakePath(PATH_EMPTY, ""),
+                     fsMakePath(PATH_ASCII, CONFIG_FILE_PATH), FS_OPEN_CREATE | FS_OPEN_WRITE);
+    if (R_SUCCEEDED(res))
+        res = IFile_SetSize(&file, sizeof(timelockData));
+    if (R_SUCCEEDED(res))
+        res = IFile_Write(&file, &written, &timelockData, sizeof(timelockData), 0);
+    IFile_Close(&file);
+}
+
+void timelockFinalSaveOnShutdown(void)
+{
+    // Called from handlePreTermNotification in main.c.
+    // Safe to call even if the thread never ran: timelockData starts zeroed
+    // and timelockSaveData just writes whatever's in RAM.
+    if (timelockData.magic == TIMELOCK_MAGIC)
+        timelockSaveData();
+}
+
+// ---- main loop --------------------------------------------------------------
+
+void timelockThreadMain(void)
+{
+    while (!isServiceUsable("hid:USER") || !isServiceUsable("fs:USER") || !isServiceUsable("APT:U"))
+        svcSleepThread(1000 * 1000 * 500LL);
+
+    hidInit();
+    fsInit();
+    aptInit();
+
+    bool homeMenuLoaded;
+    do {
+        APT_GetAppletInfo(APPID_HOMEMENU, NULL, NULL, NULL, &homeMenuLoaded, NULL);
+        svcSleepThread(1000 * 1000 * 1000 * 5LL);
+    } while (!homeMenuLoaded);
+
+    timelockLoadData();
+
+    u32 ticksSinceHeartbeat = 0;
+
+    while (!preTerminationRequested && timelockData.isEnabled) {
+        if (isRosalinaMenuOpened) {
+            svcSleepThread(1000 * 1000 * 1000 * 60LL);
+            continue;
+        }
+
+        if (menuShouldExit) {
+            svcSleepThread(1000 * 1000 * 1000 * 10LL);
+            continue;
+        }
+
+        // Per-day reset: if armed and current RTC has crossed the threshold,
+        // reset elapsed and rearm. Monotonic via the persisted timestamp:
+        // rolling the clock back doesn't help, and rolling it forward only
+        // grants ONE reset before nextResetEligibleAtMs is bumped to a new
+        // future time.
+        if (timelockData.dailyResetEnabled) {
+            s64 nowMs = timelockGetRtcMs();
+            if (nowMs > 0) {
+                if (timelockData.nextResetEligibleAtMs == 0)
+                    timelockData.nextResetEligibleAtMs = timelockComputeNextResetMs(nowMs, timelockData.resetHourLocal);
+
+                if (nowMs >= timelockData.nextResetEligibleAtMs) {
+                    timelockData.elapsedMinutes = 0;
+                    timelockData.nextResetEligibleAtMs = timelockComputeNextResetMs(nowMs, timelockData.resetHourLocal);
+                    timelockSaveData();
+                    ticksSinceHeartbeat = 0;
+                }
+            }
+        }
+
+        if (timelockData.elapsedMinutes <= timelockData.minutes) {
+            svcSleepThread(1000 * 1000 * 1000 * 60LL * MINUTES_TO_CHECK);
+
+            timelockData.elapsedMinutes += MINUTES_TO_CHECK;
+            ticksSinceHeartbeat += MINUTES_TO_CHECK;
+
+            // Coarse heartbeat keeps SD writes to <=48/day of actual play
+            // (vs valx76's 1440/day). Bounds state-loss on hard power-off
+            // to HEARTBEAT_MINUTES.
+            if (ticksSinceHeartbeat >= HEARTBEAT_MINUTES) {
+                timelockSaveData();
+                ticksSinceHeartbeat = 0;
+            }
+            continue;
+        }
+
+        resetEnteredPIN();
+
+        // Lock screen — persist BEFORE showing it so a power-pull during
+        // lock doesn't reset elapsed.
+        timelockSaveData();
+        timelockEnter();
+        timelockShow();
+        timelockLeave();
+
+        if (menuShouldExit) {
+            // Force-exited to enter sleep; do not treat as unlocked.
+            continue;
+        }
+
+        timelockData.elapsedMinutes = 0;
+        timelockSaveData();
+        ticksSinceHeartbeat = 0;
+    }
+
+    fsExit();
+    hidExit();
+}
+
+// ---- PIN entry (lock screen) ------------------------------------------------
+
+bool checkPIN(void)
+{
+    return timelockVerifyPin(enteredPIN, timelockData.pinHash, timelockData.pinSalt);
+}
+
+void resetEnteredPIN(void)
+{
+    for (int i = 0; i < PIN_LENGTH; i++)
+        enteredPIN[i] = '0';
+    pinIndex = 0;
+}
+
+void timelockInput(void)
+{
+    hidScanInput();
+    const u32 kDown = hidKeysDown();
+
+    if (kDown & KEY_DLEFT)
+        pinIndex = (pinIndex == 0 ? (PIN_LENGTH - 1) : (pinIndex - 1));
+    if (kDown & KEY_DRIGHT)
+        pinIndex = (pinIndex == (PIN_LENGTH - 1) ? 0 : (pinIndex + 1));
+    if (kDown & KEY_DDOWN)
+        enteredPIN[pinIndex] = (enteredPIN[pinIndex] == '0' ? '9' : (enteredPIN[pinIndex] - 1));
+    if (kDown & KEY_DUP)
+        enteredPIN[pinIndex] = (enteredPIN[pinIndex] == '9' ? '0' : (enteredPIN[pinIndex] + 1));
+
+    if (kDown & KEY_START)
+        isTimeLocked = !checkPIN();
+}
+
+void timelockEnter(void)
+{
+    Draw_Lock();
+    isTimeLocked = true;
+    svcKernelSetState(0x10000, 2 | 1);
+    svcSleepThread(5 * 1000 * 100LL);
+
+    if (R_FAILED(Draw_AllocateFramebufferCache(FB_BOTTOM_SIZE))) {
+        svcKernelSetState(0x10000, 2 | 1);
+        svcSleepThread(5 * 1000 * 100LL);
+    } else
+        Draw_SetupFramebuffer();
+
+    Draw_Unlock();
+}
+
+void timelockLeave(void)
+{
+    Draw_Lock();
+    Draw_RestoreFramebuffer();
+    Draw_FreeFramebufferCache();
+    svcKernelSetState(0x10000, 2 | 1);
+    Draw_Unlock();
+}
+
+static void timelockDraw(void)
+{
+    Draw_DrawString(10, 10, COLOR_TITLE, "Timelock");
+    Draw_DrawString(10, 30, COLOR_WHITE, "Enter the PIN and press START.");
+
+    for (int i = 0; i < PIN_LENGTH; i++) {
+        Draw_DrawCharacter((i+1)*10, 70, COLOR_WHITE, enteredPIN[i]);
+        Draw_DrawCharacter((i+1)*10, 90, COLOR_WHITE, (i == pinIndex ? '^' : ' '));
+    }
+    Draw_FlushFramebuffer();
+}
+
+void timelockShow(void)
+{
+    Draw_Lock();
+    Draw_ClearFramebuffer();
+    Draw_FlushFramebuffer();
+    timelockDraw();
+    Draw_Unlock();
+
+    do {
+        timelockInput();
+        Draw_Lock();
+        timelockDraw();
+        Draw_Unlock();
+    } while (isTimeLocked && !menuShouldExit);
+}


### PR DESCRIPTION
# rosalina: add timelock — limit console use with PIN-gated unlock

A revival of #1727 (valx76), addressing the SD-wear concern that blocked
that PR and adding a few improvements while in the area.

## What it does

Adds an optional time-limit subsystem to Rosalina. When enabled, the
console locks itself after a configurable amount of awake play time
(minimum 10 minutes). Unlock requires a 4-digit PIN. Configuration lives
in a new "Timelock options..." submenu of the Rosalina menu, gated by
the same PIN.

Originally pitched in #1727 by @valx76 as a parental-control feature.
Existing demand is well-documented in that thread.

## Why this is not the same PR

The only substantive objection raised in #1727's review was SD-card wear
— the original wrote the config file once per minute (1,440 writes/day
just from the timer). That made the feature a hard sell as-is.

This implementation persists the elapsed counter only on real state
transitions plus a coarse heartbeat:

| Event | Frequency |
|---|---|
| Lock-screen entry | 1× per lock |
| Successful PIN unlock | 1× per unlock |
| Settings save from menu | 1× per parent action |
| Daily-reset event | ≤1× per day |
| Shutdown | hooked from `handlePreTermNotification` |
| Heartbeat | every 30 min of *actual play* |

**Upper bound: 48 writes/day** even during continuous play. Realistic
numbers for a typical day (a few hours, one lock/unlock cycle):
**4–8 writes**. Down from 1,440. Worst-case state loss on hard
power-pull is bounded to 30 minutes (the heartbeat interval).

## Other improvements over #1727

**PIN hashing.** PIN is stored as `SHA-256(salt || pin)` with a
per-install 16-byte salt generated via `PS_GenerateRandomBytes`
(falling back to a tick-driven LCG if `ps` isn't available).
Plaintext PIN never lives in the config file. Verification uses
constant-time compare. Vendored a minimal FIPS 180-4 SHA-256
implementation (~120 LoC, public domain, separate commit) since
libctru doesn't expose a general SHA primitive for in-memory data.

**Optional daily reset.** Off by default. When enabled, the elapsed
counter auto-resets at a configurable RTC hour each day. Monotonic
clock-tamper guard: the next-eligible reset timestamp is persisted, so
rolling the clock back doesn't undo state, and rolling it forward
grants exactly **one** reset before the timestamp re-arms to a new
future value (so the cost of exploiting equals the cost of just
waiting).

**Config schema versioning.** New struct carries a 32-bit magic
(`'TLCK'`) + 16-bit version. Any mismatch — including legacy plaintext-
PIN files from #1727 builds — is treated as absent and replaced with
defaults. No migration code, no support burden if the schema changes
again.

## Honest limitations

Worth calling out explicitly so this isn't oversold:

- **Trivially bypassable with SD-card access** — a child with a PC can
  wipe `/luma/timelock_config.bin` and start fresh, or read the on-disk
  state. This is a friction layer for casual circumvention, not
  security. The PIN hash means the on-SD value isn't directly readable
  as a PIN, but the file can still just be deleted.
- **RTC manipulation** can still grant one daily-reset per real-time
  day passing (the monotonic guard bounds it, doesn't eliminate it).
- **Hard power-off** loses up to 30 minutes of elapsed state.

## Architecture

- New low-priority sysmodule thread on `CORE_SYSTEM`, ticking every
  minute while awake.
- Sleep mode (lid closed) and Rosalina menu being open both pause
  counting.
- Lock screen uses the same framebuffer-takeover mechanism Rosalina's
  own menu uses (`svcKernelSetState(0x10000, 2 | 1)` + framebuffer
  cache alloc).
- Menu integration: insert one entry in `rosalinaMenu` and one
  init call after `Draw_Init()`. Plays nicely with the existing
  `g_blockMenuOpen` flag — when locked, the Rosalina menu combo is
  ignored.

## Files

| File | Change |
|---|---|
| `sysmodules/rosalina/include/sha256.h` | + |
| `sysmodules/rosalina/source/sha256.c` | + |
| `sysmodules/rosalina/include/timelock.h` | + |
| `sysmodules/rosalina/include/timelock_shared_config.h` | + |
| `sysmodules/rosalina/source/timelock.c` | + |
| `sysmodules/rosalina/include/menus/timelock_config.h` | + |
| `sysmodules/rosalina/source/menus/timelock_config.c` | + |
| `sysmodules/rosalina/source/main.c` | one init call, one shutdown hook |
| `sysmodules/rosalina/source/menu.c` | one guard in the menu-open check |
| `sysmodules/rosalina/source/menus.c` | one entry added to `rosalinaMenu` |
| `sysmodules/rosalina/include/menu.h` | one declaration |

Two commits:
1. `rosalina: vendor minimal SHA-256 (FIPS 180-4)` — standalone, ~120 LoC
2. `rosalina: add timelock — limit console use with PIN-gated unlock` — everything else

## Test status

- Builds cleanly against current `master`.
- Verified on hardware (N3DS XL, current Luma master + this PR's
  changes):
  - Boot, menu navigation, PIN entry, time accrual, lock screen,
    unlock, save/reload, daily reset, clock-rollback rejection.
  - Old plaintext-PIN config from a #1727-based build gracefully
    replaced on first boot.

## Credits

Original feature design and most of the menu structure: @valx76 (#1727).
This PR squashes those 12 commits down to the current Luma master and
addresses the wear concern, plus the additions above.
