### PR TITLE
Fix Local Play and StreetPass after call miniSocInit

### DIFF
--- a/k11_extension/include/globals.h
+++ b/k11_extension/include/globals.h
@@ -172,7 +172,7 @@ extern u32 stolenSystemMemRegionSize;
 extern bool disableThreadRedirection;
 
 extern vu32 rosalinaState;
-extern bool hasStartedRosalinaNetworkFuncsOnce;
+extern bool hasStartedRosalinaNetworkFuncs;
 extern KEvent* signalPluginEvent;
 
 typedef enum

--- a/k11_extension/source/globals.c
+++ b/k11_extension/source/globals.c
@@ -130,7 +130,7 @@ u32 stolenSystemMemRegionSize;
 bool disableThreadRedirection = false;
 
 vu32 rosalinaState;
-bool hasStartedRosalinaNetworkFuncsOnce;
+bool hasStartedRosalinaNetworkFuncs;
 KEvent* signalPluginEvent = NULL;
 u32 pidOffsetKProcess, hwInfoOffsetKProcess, codeSetOffsetKProcess, handleTableOffsetKProcess, debugOffsetKProcess, flagsKProcess;
 

--- a/k11_extension/source/main.c
+++ b/k11_extension/source/main.c
@@ -396,7 +396,7 @@ void main(FcramLayout *layout, KCoreContext *ctxs)
     nbSection0Modules = (u32)nb;
 
     rosalinaState = 0;
-    hasStartedRosalinaNetworkFuncsOnce = false;
+    hasStartedRosalinaNetworkFuncs = false;
 
     // DSB, Flush Prefetch Buffer (more or less "isb")
     __asm__ __volatile__ ("mcr p15, 0, %0, c7, c10, 4" :: "r" (0) : "memory");

--- a/k11_extension/source/svc/KernelSetState.c
+++ b/k11_extension/source/svc/KernelSetState.c
@@ -121,8 +121,7 @@ Result KernelSetStateHook(u32 type, u32 varg1, u32 varg2, u32 varg3)
             while(__strex((s32 *)&rosalinaState, (s32)(rosalinaState ^ varg1)));
             __dmb();
 
-            if(rosalinaState & 0x10)
-                hasStartedRosalinaNetworkFuncsOnce = true;
+            hasStartedRosalinaNetworkFuncs = rosalinaState & 0x10;
 
             // 1: all applet/app/dsp/csnd... threads 2: gsp 4: hid/ir
             for (u32 v = 4; v != 0; v >>= 1)

--- a/k11_extension/source/svc/SendSyncRequest.c
+++ b/k11_extension/source/svc/SendSyncRequest.c
@@ -30,7 +30,7 @@
 
 static inline bool isNdmuWorkaround(const SessionInfo *info, u32 pid)
 {
-    return info != NULL && strcmp(info->name, "ndm:u") == 0 && hasStartedRosalinaNetworkFuncsOnce && pid >= nbSection0Modules;
+    return info != NULL && strcmp(info->name, "ndm:u") == 0 && hasStartedRosalinaNetworkFuncs && pid >= nbSection0Modules;
 }
 
 Result SendSyncRequestHook(Handle handle)
@@ -139,7 +139,7 @@ Result SendSyncRequestHook(Handle handle)
 
             case 0x80040:
             {
-                if(!hasStartedRosalinaNetworkFuncsOnce)
+                if(!hasStartedRosalinaNetworkFuncs)
                     break;
                 SessionInfo *info = SessionInfo_Lookup(clientSession->parentSession);
                 skip = isNdmuWorkaround(info, pid); // SuspendScheduler
@@ -150,7 +150,7 @@ Result SendSyncRequestHook(Handle handle)
 
             case 0x90000:
             {
-                if(!hasStartedRosalinaNetworkFuncsOnce)
+                if(!hasStartedRosalinaNetworkFuncs)
                     break;
                 SessionInfo *info = SessionInfo_Lookup(clientSession->parentSession);
                 if(isNdmuWorkaround(info, pid)) // ResumeScheduler


### PR DESCRIPTION
Hi, this PR is here to fix a bug after usage of `minisoc` (enable then disable) described here: [https://github.com/LumaTeam/Luma3DS/issues/2180](https://github.com/LumaTeam/Luma3DS/issues/2180)

TLDR; change the behavior of the `hasStartedRosalinaNetworkFuncsOnce` variable to prevent it from permanently breaking local communication after first `miniSocInit`

---

So after some research, I found the cause of this bug.
When the 3DS wants to use a local connection, the console uses `NDMU_EnterExclusiveState()` to force only local connections.

If we look in `libctru`, `NDMU_EnterExclusiveState` calls `svcSendSyncRequest` with `cmdbuf[0] = 0x10042`.

Luma captures this call in the function `SendSyncRequestHook`. In this function, Luma captures the `0x10042`, and if `isNdmuWorkaround` returns `true`, the variable `skip` becomes `true` and `NDMU_EnterExclusiveState` doesn't work.

So this function `isNdmuWorkaround` is the cause of this bug.

```c
static inline bool isNdmuWorkaround(const SessionInfo *info, u32 pid)
{
    return info != NULL && strcmp(info->name, "ndm:u") == 0 && hasStartedRosalinaNetworkFuncsOnce && pid >= nbSection0Modules;
}

```

So here the interesting thing is `hasStartedRosalinaNetworkFuncsOnce`. This variable is set to `false` once in the `main`, and becomes `true` in the function `KernelSetStateHook`, in case `0x10000` when `(rosalinaState & 0x10)`.

`miniSocInit` and `miniSocExitDirect` both call `svcKernelSetState(0x10000, 0x10)`, going into the function `KernelSetStateHook`. In this function, Luma does `rosalinaState ^ varg1`, so `rosalinaState ^ 0x10`. In `miniSocInit`, it enables `hasStartedRosalinaNetworkFuncsOnce`. But when we call again `svcKernelSetState(0x10000, 0x10)` in `miniSocExitDirect`, `hasStartedRosalinaNetworkFuncsOnce` stays at `true` afterward; given the name of the variable, it looks normal. But in `isNdmuWorkaround`, it's breaking local communication.

`hasStartedRosalinaNetworkFuncsOnce` is also used in scheduler NDM (`0x80040` and `0x90000`), so I think it's also a problem there.

So, my workaround is to change the behavior of this variable. Instead of having this variable once set to `true` never be able to go back to `false`, I propose to reset it to `false` in the case of `miniSocExitDirect`. This allows fixing the bug without breaking other functions that use this variable. I also rename the variable to `hasStartedRosalinaNetworkFuncs` because it's not a "once" variable anymore.

Before:

```c
if(rosalinaState & 0x10)
    hasStartedRosalinaNetworkFuncsOnce = true;

```

After:

```c
hasStartedRosalinaNetworkFuncs = rosalinaState & 0x10;

```

PR written by me (@LeonLeBreton) and tested by @cooolgamer