### PR TITLE
loader: add experimental HOME Menu ExeFS overrides

### DIFF
--- a/docs/exefs-overrides.md
+++ b/docs/exefs-overrides.md
@@ -1,0 +1,93 @@
+# Experimental HOME Menu ExeFS overrides
+
+With **Enable game patching** enabled, the loader attempts to patch HOME Menu's
+`OpenFileDirectly` call so it can open replacement files on the SD card:
+
+```text
+/luma/titles/<16-digit uppercase TitleID>/exefs/banner
+/luma/titles/<16-digit uppercase TitleID>/exefs/icon
+```
+
+Use the game's base TitleID (or the demo's TitleID), not HOME Menu's TitleID or
+an update's TitleID. The files have no extension: `icon` is a complete SMDH and
+`banner` is a complete ExeFS banner. Restart HOME Menu after enabling the patch.
+
+## Scope and behavior
+
+* This targets HOME Menu's **reads of other titles**, before those titles are
+  launched. Adding paths to the game's existing RomFS redirection would not
+  intercept these reads.
+* Only CTR applications (`00040000`) and demos (`00040002`), main content index
+  zero, and exact `icon`/`banner` names are eligible. NAND, SD, and gamecard
+  source media use the same per-TitleID replacement path.
+* Replacement files are opened read-only. If the replacement open fails,
+  including an IPC transport failure, the original request is restored and
+  sent normally. Once a replacement opens successfully, its handle is returned
+  directly; malformed files or later read errors do not cause another fallback.
+* This first implementation requires Luma to be running in SD mode. CTRNAND
+  replacements, other processes' reads, archive-handle-based `OpenFile` calls,
+  RomFS, `.code`, update content, and `logo` are outside its scope.
+* HOME Menu's icon cache is not modified or invalidated. Existing cached icons
+  may remain visible, including after removing an override. Extended banners
+  supplied through extdata can also take precedence over the ExeFS banner.
+* No console/HOME Menu version has yet been validated with this implementation.
+  Unsupported code layouts leave the original call unchanged; compilation and
+  synthetic execution tests alone do not establish HOME Menu compatibility.
+
+## Implementation
+
+The installer runs in the existing game-patching block for the six HOME Menu
+TitleIDs, after IPS/BPS and RomFS patches. It requires an ARM literal load of the
+`OpenFileDirectly` IPC header and a unique call to a `svc 0x32; bx lr` wrapper
+in that function. It changes that call, rather than globally intercepting SVC
+requests. Ambiguous matches are rejected without modifying the executable.
+
+The position-independent ARM payload is placed in zero-filled `.text` page
+padding. Space for the existing RomFS payload is reserved at the beginning of
+the padding; existing code and data are not reclaimed. If insufficient padding
+is available, the new hook is skipped rather than preventing HOME Menu startup.
+Neither the kernel nor Process9 is changed.
+
+The IPC layout follows [libctru's OpenFileDirectly implementation](https://github.com/devkitPro/libctru/blob/36fe1ada5b7ebe53ba4decda36d764a55f8fefb6/libctru/source/services/fs.c).
+The title-content binary paths are also used by
+[FBI's SMDH reader](https://github.com/Steveice10/FBI/blob/ec259153e25fc77ee999b8caadac7e73d2e5e41a/source/fbi/task/listtitles.c).
+
+Every invocation uses 160 bytes of stack, including saved registers, a complete
+52-byte IPC request, and the replacement path. There is no shared mutable
+payload state and no additional FS session or archive lifetime to manage.
+
+## Automated validation
+
+Build normally with devkitARM, libctru, makerom, and firmtool. Then run:
+
+```sh
+python3 -m pip install unicorn pyelftools
+python3 tests/test_exefsredir.py sysmodules/loader/loader.elf
+```
+
+The tests execute the built ARM installer and a relocated copy of the payload.
+They exercise file paths, both allowed title classes, all source media types,
+IPC and file-open failure fallback, request filtering, stack/register
+preservation, ambiguous/missing SDK patterns, occupied/insufficient padding,
+backward calls, and coexistence with reserved RomFS padding. FS replies are
+stubbed; these tests do not emulate the 3DS filesystem or HOME Menu.
+
+## Hardware validation required before marking the PR ready
+
+Record the console model, system version, region, HOME Menu TitleID/version,
+and exact Luma commit for each test. Keep a known-good `boot.firm` for rollback.
+
+1. Verify that the call is actually patched on a legally obtained HOME Menu
+   code dump, or inspect the loaded code with a debugger. A successful boot
+   alone is not evidence that the optional hook was installed.
+2. Use valid replacement icon/banner files for a test application. Check the
+   displayed icon, localized title, banner model, and banner audio. Account for
+   an existing icon cache; back it up before any manual cache refresh.
+3. Test a digital title, a gamecard title, and a demo; compare against an
+   unmodified title and test with only one of the two override files present.
+4. Remove the override files, test with game patching disabled, and repeat
+   after restarting HOME Menu. Confirm ordinary titles still open and launch.
+5. Test alongside HOME Menu RomFS patches and the target game's RomFS, IPS/BPS,
+   and locale patches. Exercise suspend/resume and repeated title selection.
+6. Confirm behavior on Old and New 3DS and multiple regions/versions. Record
+   unsupported code layouts explicitly rather than reporting them as passes.

--- a/sysmodules/loader/source/exefsredir.c
+++ b/sysmodules/loader/source/exefsredir.c
@@ -1,0 +1,62 @@
+#include <string.h>
+#include "exefsredir.h"
+
+extern const u8 exefsRedirPatch[];
+extern const u32 exefsRedirPatchSize;
+
+bool patchHomeMenuExefs(u8 *code, u32 size, u32 textSize, u32 reservedPadding)
+{
+    const u32 payloadSize = exefsRedirPatchSize;
+    if(textSize < 8 || textSize > size || textSize > 0xFFFFF000 || (textSize & 3)) return false;
+
+    const u32 roundedTextSize = (textSize + 0xFFF) & ~0xFFF;
+    if(roundedTextSize > size || payloadSize > roundedTextSize - textSize ||
+       reservedPadding > roundedTextSize - textSize - payloadSize) return false;
+
+    const u32 payloadOffset = (roundedTextSize - payloadSize) & ~3;
+    if(payloadOffset < textSize + reservedPadding) return false;
+    for(u32 i = payloadOffset; i < roundedTextSize; i++)
+        if(code[i] != 0) return false;
+
+    // Find the ARM SDK OpenFileDirectly implementation by an actual literal
+    // load of its IPC header, not by the presence of that constant alone.
+    // Only redirect its call to the two-instruction svcSendSyncRequest stub.
+    u32 call = 0xFFFFFFFF;
+    const u32 *words = (const u32 *)code;
+    for(u32 pos = 0; pos <= textSize - 8; pos += 4)
+    {
+        const u32 insn = words[pos / 4];
+        if((insn & 0xFFFF0000) != 0xE59F0000) continue; // ldr rN, [pc, #imm]
+        const u32 literal = pos + 8 + (insn & 0xFFF);
+        if((literal & 3) || literal > textSize - 4 || words[literal / 4] != 0x08030204) continue;
+
+        u32 start = pos;
+        while(start >= 4 && (words[start / 4] & 0xFFFF4000) != 0xE92D4000) start -= 4;
+        if((words[start / 4] & 0xFFFF4000) != 0xE92D4000) continue;
+
+        u32 candidate = 0xFFFFFFFF;
+        for(u32 at = start + 4; at < literal; at += 4)
+        {
+            const u32 branch = words[at / 4];
+            if((branch & 0xFFFF0000) == 0xE92D0000) break;
+            if((branch & 0xFF000000) != 0xEB000000) continue;
+            const s32 displacement = ((s32)(branch << 8) >> 8) * 4;
+            const s64 target = (s64)at + 8 + displacement;
+            if(target < 0 || target > textSize - 8) continue;
+            if(words[target / 4] != 0xEF000032 || words[target / 4 + 1] != 0xE12FFF1E) continue;
+            if(candidate != 0xFFFFFFFF) return false;
+            candidate = at;
+        }
+        if(candidate == 0xFFFFFFFF) continue;
+        if(call != 0xFFFFFFFF && call != candidate) return false;
+        call = candidate;
+    }
+
+    if(call == 0xFFFFFFFF) return false;
+    const s64 displacement = (s64)payloadOffset - call - 8;
+    if(displacement < -0x2000000 || displacement > 0x1FFFFFC) return false;
+
+    memcpy(code + payloadOffset, exefsRedirPatch, payloadSize);
+    *(u32 *)(code + call) = 0xEB000000 | (((u32)displacement >> 2) & 0xFFFFFF);
+    return true;
+}

--- a/sysmodules/loader/source/exefsredir.h
+++ b/sysmodules/loader/source/exefsredir.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#include <3ds/types.h>
+
+// Returns false without modifying code when the SDK call or padding is unknown.
+bool patchHomeMenuExefs(u8 *code, u32 size, u32 textSize, u32 reservedPadding);

--- a/sysmodules/loader/source/exefsredir_payload.s
+++ b/sysmodules/loader/source/exefsredir_payload.s
@@ -1,0 +1,190 @@
+@ HOME Menu ExeFS overrides. Called in place of a BL to svcSendSyncRequest
+@ inside FSUSER_OpenFileDirectly; r0 is the FS session, lr is the return site.
+@ All scratch storage is per-call, including paths used by synchronous IPC.
+
+.section .rodata.exefsRedirPatch, "a", %progbits
+.arm
+.balign 4
+.global exefsRedirPatch
+exefsRedirPatch:
+    push    {r0-r12, lr}
+    mrc     p15, 0, r4, c13, c0, 3
+    add     r4, r4, #0x80
+    ldr     r1, [r4]
+    ldr     r2, =0x08030204
+    cmp     r1, r2
+    bne     original
+    ldr     r1, [r4, #4]
+    cmp     r1, #0                  @ No transaction
+    bne     original
+    ldr     r1, [r4, #8]
+    ldr     r2, =0x2345678A         @ Title content archive
+    cmp     r1, r2
+    bne     original
+    ldr     r1, [r4, #12]
+    cmp     r1, #2                  @ PATH_BINARY
+    ldreq   r1, [r4, #16]
+    cmpeq   r1, #16
+    ldreq   r1, [r4, #20]
+    cmpeq   r1, #2
+    ldreq   r1, [r4, #24]
+    cmpeq   r1, #20
+    ldreq   r1, [r4, #28]
+    cmpeq   r1, #1                  @ Read only
+    ldreq   r1, [r4, #32]
+    cmpeq   r1, #0                  @ No attributes
+    bne     original
+    ldr     r1, [r4, #36]
+    ldr     r2, =0x40802            @ Archive static buffer: 16 bytes, id 2
+    cmp     r1, r2
+    ldreq   r1, [r4, #44]
+    ldreq   r2, =0x50002            @ File static buffer: 20 bytes, id 0
+    cmpeq   r1, r2
+    bne     original
+    ldr     r7, [r4, #40]
+    ldr     r6, [r4, #48]
+    cmp     r7, #0
+    cmpne   r6, #0
+    beq     original
+    orr     r1, r6, r7
+    tst     r1, #3
+    bne     original
+    ldr     r1, [r7, #4]
+    bic     r1, r1, #2              @ CTR applications and demos only
+    ldr     r2, =0x00040000
+    cmp     r1, r2
+    bne     original
+    ldr     r1, [r7, #8]
+    cmp     r1, #2                  @ NAND, SD, or gamecard
+    bhi     original
+    ldr     r1, [r7, #12]
+    cmp     r1, #0
+    ldreq   r1, [r6]
+    cmpeq   r1, #0                  @ High-level NCCH access
+    ldreq   r1, [r6, #4]
+    cmpeq   r1, #0                  @ Main content only
+    ldreq   r1, [r6, #8]
+    cmpeq   r1, #2                  @ System Menu Data
+    bne     original
+    ldr     r1, [r6, #12]
+    ldr     r2, =0x6E6F6369         @ icon\0\0\0\0
+    cmp     r1, r2
+    bne     checkBanner
+    ldr     r1, [r6, #16]
+    cmp     r1, #0
+    bne     original
+    b       redirect
+checkBanner:
+    ldr     r2, =0x6E6E6162         @ banner\0\0
+    cmp     r1, r2
+    ldreq   r1, [r6, #16]
+    ldreq   r2, =0x00007265
+    cmpeq   r1, r2
+    bne     original
+
+redirect:
+    mov     r5, r0
+    sub     sp, sp, #104            @ 52-byte request, padding, 44-byte path
+    mov     r1, #0
+saveRequest:
+    ldr     r2, [r4, r1]
+    str     r2, [sp, r1]
+    add     r1, r1, #4
+    cmp     r1, #52
+    bne     saveRequest
+    add     r8, sp, #56
+    adr     r2, pathPrefix
+    mov     r1, #0
+copyPrefix:
+    ldrb    r3, [r2, r1]
+    strb    r3, [r8, r1]
+    add     r1, r1, #1
+    cmp     r1, #13
+    bne     copyPrefix
+    add     r8, r8, #13
+    ldr     r2, [r7, #4]
+    bl      hexWord
+    ldr     r2, [r7]
+    bl      hexWord
+    adr     r2, pathSuffix
+    mov     r1, #0
+copySuffix:
+    ldrb    r3, [r2, r1]
+    strb    r3, [r8, r1]
+    add     r1, r1, #1
+    cmp     r1, #7
+    bne     copySuffix
+    add     r8, r8, #7
+    add     r6, r6, #12
+copyName:
+    ldrb    r3, [r6], #1
+    strb    r3, [r8], #1
+    cmp     r3, #0
+    bne     copyName
+
+    mov     r1, #9                  @ ARCHIVE_SDMC
+    str     r1, [r4, #8]
+    mov     r1, #1                  @ PATH_EMPTY
+    str     r1, [r4, #12]
+    str     r1, [r4, #16]
+    mov     r1, #3                  @ PATH_ASCII
+    str     r1, [r4, #20]
+    add     r2, sp, #56
+    sub     r1, r8, r2              @ Includes terminator
+    str     r1, [r4, #24]
+    str     r2, [r4, #48]
+    mov     r1, r1, lsl #14
+    orr     r1, r1, #2
+    str     r1, [r4, #44]
+    ldr     r1, =0x4802             @ Empty archive static buffer
+    str     r1, [r4, #36]
+    sub     r1, r8, #1              @ Point at the path's NUL byte
+    str     r1, [r4, #40]
+    mov     r0, r5
+    svc     0x32
+    cmp     r0, #0
+    blt     fallback
+    ldr     r1, [r4, #4]
+    cmp     r1, #0
+    bge     redirected
+fallback:
+    mov     r1, #0
+restoreRequest:
+    ldr     r2, [sp, r1]
+    str     r2, [r4, r1]
+    add     r1, r1, #4
+    cmp     r1, #52
+    bne     restoreRequest
+    add     sp, sp, #104
+original:
+    pop     {r0-r12, lr}
+    svc     0x32
+    bx      lr
+redirected:
+    add     sp, sp, #108            @ Discard scratch and saved r0
+    pop     {r1-r12, lr}
+    bx      lr
+
+hexWord:
+    mov     r9, #8
+hexDigit:
+    mov     r3, r2, lsr #28
+    cmp     r3, #10
+    addlo   r3, r3, #'0'
+    addhs   r3, r3, #('A' - 10)
+    strb    r3, [r8], #1
+    mov     r2, r2, lsl #4
+    subs    r9, r9, #1
+    bne     hexDigit
+    bx      lr
+
+.pool
+pathPrefix: .ascii "/luma/titles/"
+.balign 4
+pathSuffix: .ascii "/exefs/"
+.balign 4
+.global exefsRedirPatchEnd
+exefsRedirPatchEnd:
+.global exefsRedirPatchSize
+exefsRedirPatchSize:
+    .word exefsRedirPatchEnd - exefsRedirPatch

--- a/sysmodules/loader/source/patcher.c
+++ b/sysmodules/loader/source/patcher.c
@@ -4,6 +4,7 @@
 #include "memory.h"
 #include "strings.h"
 #include "romfsredir.h"
+#include "exefsredir.h"
 #include "util.h"
 
 static u32 patchMemory(u8 *start, u32 size, const void *pattern, u32 patSize, s32 offset, const void *replace, u32 repSize, u32 count)
@@ -1011,6 +1012,11 @@ void patchCode(u64 progId, u16 progVer, u8 *code, u32 size, u32 textSize, u32 ro
             if(isLumaWithKext && loadTitleLocaleConfig(progId, &mask, &regionId, &languageId, &countryId, &stateId))
                 svcKernelSetState(0x10001, ((u32)stateId << 24) | ((u32)countryId << 16) | ((u32)languageId << 8) | ((u32)regionId << 4) | (u32)mask , progId);
             if(!patchLayeredFs(progId, code, size, textSize, roSize, dataSize, roAddress, dataAddress)) goto error;
+            // HOME Menu opens other titles' ExeFS before those titles run.
+            // Leave room for the existing RomFS payload and do not make an
+            // unrecognized HOME Menu SDK or occupied padding a boot failure.
+            if(isHomeMenu && isSdMode)
+                patchHomeMenuExefs(code, size, textSize, romfsRedirPatchSize);
         }
     }
 

--- a/tests/test_exefsredir.py
+++ b/tests/test_exefsredir.py
@@ -1,0 +1,245 @@
+"""Execute the built ARM installer and payload, with FS IPC supplied by a stub.
+
+Usage: python3 tests/test_exefsredir.py sysmodules/loader/loader.elf
+Requires unicorn and pyelftools. No Nintendo binaries or content are used.
+This verifies machine code and the IPC contract, not HOME Menu compatibility.
+"""
+import struct
+import sys
+import unittest
+
+from elftools.elf.elffile import ELFFile
+from unicorn import Uc, UC_ARCH_ARM, UC_MODE_ARM, UC_HOOK_INTR
+from unicorn.arm_const import (
+    UC_ARM_REG_R0, UC_ARM_REG_R1, UC_ARM_REG_R2, UC_ARM_REG_R3,
+    UC_ARM_REG_R4, UC_ARM_REG_R5, UC_ARM_REG_R6, UC_ARM_REG_R7,
+    UC_ARM_REG_R8, UC_ARM_REG_R9, UC_ARM_REG_R10, UC_ARM_REG_R11,
+    UC_ARM_REG_R12, UC_ARM_REG_SP, UC_ARM_REG_LR, UC_ARM_REG_C13_C0_3,
+)
+
+ELF_PATH = sys.argv.pop(1)
+REGS = [UC_ARM_REG_R0, UC_ARM_REG_R1, UC_ARM_REG_R2, UC_ARM_REG_R3,
+        UC_ARM_REG_R4, UC_ARM_REG_R5, UC_ARM_REG_R6, UC_ARM_REG_R7,
+        UC_ARM_REG_R8, UC_ARM_REG_R9, UC_ARM_REG_R10, UC_ARM_REG_R11,
+        UC_ARM_REG_R12]
+CODE, DATA, STACK, STOP = 0x20000000, 0x30000000, 0x31000000, 0x32000000
+TLS, ARCHIVE, FILE = DATA, DATA + 0x1000, DATA + 0x2000
+
+
+def pack(words):
+    return struct.pack('<' + 'I' * len(words), *words)
+
+
+def branch(at, target):
+    return 0xEB000000 | (((target - at - 8) // 4) & 0xFFFFFF)
+
+
+class ExefsTests(unittest.TestCase):
+    def setUp(self):
+        self.uc = Uc(UC_ARCH_ARM, UC_MODE_ARM)
+        with open(ELF_PATH, 'rb') as stream:
+            elf = ELFFile(stream)
+            self.symbols = {s.name: s['st_value'] for s in elf.get_section_by_name('.symtab').iter_symbols()}
+            pages = set()
+            for seg in elf.iter_segments():
+                if seg['p_type'] != 'PT_LOAD':
+                    continue
+                start, end = seg['p_vaddr'], seg['p_vaddr'] + seg['p_memsz']
+                for page in range(start & ~4095, (end + 4095) & ~4095, 4096):
+                    if page not in pages:
+                        self.uc.mem_map(page, 4096)
+                        pages.add(page)
+                self.uc.mem_write(start, seg.data())
+        for addr, size in [(CODE, 0x4000), (DATA, 0x4000), (STACK, 0x10000), (STOP, 0x1000)]:
+            self.uc.mem_map(addr, size)
+        self.uc.reg_write(UC_ARM_REG_C13_C0_3, TLS)
+        self.uc.reg_write(UC_ARM_REG_SP, STACK + 0xF000)
+        self.uc.reg_write(UC_ARM_REG_LR, STOP)
+        self.calls = []
+        self.responses = [(0, 0)]
+        self.uc.hook_add(UC_HOOK_INTR, self.service)
+
+    def service(self, uc, interrupt, _):
+        self.assertEqual(interrupt, 2)  # ARM SVC
+        cmd = list(struct.unpack('<13I', uc.mem_read(TLS + 0x80, 52)))
+        archive = bytes(uc.mem_read(cmd[10], cmd[4]))
+        path = bytes(uc.mem_read(cmd[12], cmd[6]))
+        self.calls.append((cmd, archive, path, uc.reg_read(UC_ARM_REG_R0)))
+        transport, result = self.responses[min(len(self.calls) - 1, len(self.responses) - 1)]
+        # Overwrite every request word to exercise complete fallback restoration.
+        uc.mem_write(TLS + 0x80, pack([0x8030042, result, 0, 0x1234] + [0xBAD] * 9))
+        uc.reg_write(UC_ARM_REG_R0, transport)
+        # SVC caller-saved registers must not be used to recover the original call.
+        for reg in REGS[1:4]:
+            uc.reg_write(reg, 0xBADBAD)
+
+    def fixture(self):
+        data = bytearray(0x1000)
+        for offset, value in {
+            0x20: 0xE92D4010, 0x24: 0xE59F1014, 0x28: branch(0x28, 0x80),
+            0x2C: 0xE8BD8010, 0x40: 0x08030204, 0x80: 0xEF000032, 0x84: 0xE12FFF1E,
+        }.items():
+            struct.pack_into('<I', data, offset, value)
+        return data
+
+    def install(self, data=None, size=0x1000, text=0x200, reserve=512):
+        if data is None:
+            data = self.fixture()
+        self.uc.mem_write(CODE, bytes(data))
+        for reg, val in zip(REGS, [CODE, size, text, reserve]):
+            self.uc.reg_write(reg, val)
+        self.uc.reg_write(UC_ARM_REG_LR, STOP)
+        self.uc.emu_start(self.symbols['patchHomeMenuExefs'], STOP, count=100000)
+        return self.uc.reg_read(UC_ARM_REG_R0), bytes(self.uc.mem_read(CODE, len(data)))
+
+    def prepare(self, name='icon', title=0x0004000000086300, media=1):
+        archive = pack([title & 0xFFFFFFFF, title >> 32, media, 0])
+        file = pack([0, 0, 2]) + name.encode().ljust(8, b'\0')
+        self.uc.mem_write(ARCHIVE, archive)
+        self.uc.mem_write(FILE, file)
+        cmd = [0x08030204, 0, 0x2345678A, 2, 16, 2, 20, 1, 0,
+               0x40802, ARCHIVE, 0x50002, FILE]
+        self.uc.mem_write(TLS + 0x80, pack(cmd))
+        return cmd, archive, file
+
+    def run_payload(self):
+        initial = [0x71] + [0xAB00 + n for n in range(1, 13)]
+        for reg, value in zip(REGS, initial):
+            self.uc.reg_write(reg, value)
+        self.uc.reg_write(UC_ARM_REG_LR, STOP)
+        sp = self.uc.reg_read(UC_ARM_REG_SP)
+        self.uc.mem_write(sp - 176, b'G' * 16)
+        self.uc.mem_write(sp, b'G' * 16)
+        payload = self.symbols['exefsRedirPatch']
+        length = self.symbols['exefsRedirPatchEnd'] - payload
+        # Execute a relocated copy, as HOME Menu does, to catch absolute references.
+        self.uc.mem_write(CODE + 0x2000, bytes(self.uc.mem_read(payload, length)))
+        self.uc.emu_start(CODE + 0x2000, STOP, count=10000)
+        self.assertEqual(self.uc.reg_read(UC_ARM_REG_SP), sp)
+        self.assertEqual(bytes(self.uc.mem_read(sp - 176, 16)), b'G' * 16)
+        self.assertEqual(bytes(self.uc.mem_read(sp, 16)), b'G' * 16)
+        self.assertEqual(self.uc.reg_read(UC_ARM_REG_LR), STOP)
+        for reg, value in zip(REGS[4:], initial[4:]):
+            self.assertEqual(self.uc.reg_read(reg), value)
+        self.assertTrue(all(call[3] == initial[0] for call in self.calls))
+
+    def test_installer(self):
+        ok, data = self.install()
+        self.assertEqual(ok, 1)
+        insn = struct.unpack_from('<I', data, 0x28)[0]
+        target = 0x28 + 8 + ((insn & 0xFFFFFF) << 2)
+        payload = self.symbols['exefsRedirPatch']
+        length = self.symbols['exefsRedirPatchEnd'] - payload
+        self.assertEqual(data[target:target + length], bytes(self.uc.mem_read(payload, length)))
+        expected = self.fixture()
+        expected[0x28:0x2C] = data[0x28:0x2C]
+        expected[target:target + length] = data[target:target + length]
+        self.assertEqual(data, expected)
+
+    def test_installer_rejects_without_writes(self):
+        variants = []
+        for offset, value in [(0x24, 0xE1A00000), (0x24, 0xE59F1FFF),
+                              (0x24, 0xE59F1015), (0x20, 0xE92D0010),
+                              (0x84, 0xE1A00000), (0xFFC, 1)]:
+            data = self.fixture()
+            struct.pack_into('<I', data, offset, value)
+            variants.append((data, {}))
+        ambiguous = self.fixture()
+        struct.pack_into('<I', ambiguous, 0x30, branch(0x30, 0x80))
+        variants.append((ambiguous, {}))
+        for kwargs in [dict(size=0x100), dict(text=0), dict(text=0x201), dict(text=0x1000),
+                       dict(reserve=0x1000), dict(text=0xFFFFFFFC, size=0xFFFFFFFF)]:
+            variants.append((self.fixture(), kwargs))
+        for data, kwargs in variants:
+            with self.subTest(kwargs=kwargs, changed=[i for i, v in enumerate(data) if v]):
+                ok, after = self.install(data, **kwargs)
+                self.assertEqual(ok, 0)
+                self.assertEqual(after, data)
+
+    def test_installer_preserves_romfs_padding(self):
+        data = self.fixture()
+        data[0x200:0x400] = b'R' * 512
+        ok, after = self.install(data)
+        self.assertEqual(ok, 1)
+        self.assertEqual(after[0x200:0x400], b'R' * 512)
+        ok, again = self.install(after)
+        self.assertEqual(ok, 0)
+        self.assertEqual(again, after)
+
+    def test_installer_backward_svc_branch(self):
+        data = self.fixture()
+        struct.pack_into('<II', data, 0, 0xEF000032, 0xE12FFF1E)
+        struct.pack_into('<I', data, 0x28, branch(0x28, 0))
+        ok, _ = self.install(data)
+        self.assertEqual(ok, 1)
+
+    def test_installer_ambiguous_functions(self):
+        data = self.fixture()
+        for at, value in {0x100: 0xE92D4010, 0x104: 0xE59F1014,
+                          0x108: branch(0x108, 0x80), 0x120: 0x08030204}.items():
+            struct.pack_into('<I', data, at, value)
+        ok, after = self.install(data)
+        self.assertEqual(ok, 0)
+        self.assertEqual(after, data)
+
+    def test_success_paths(self):
+        for name in ['icon', 'banner']:
+            for media in [0, 1, 2]:
+                for title in [0x0004000000086300, 0x00040002ABCDEF00]:
+                    with self.subTest(name=name, media=media, title=title):
+                        self.calls.clear()
+                        self.prepare(name, title, media)
+                        self.run_payload()
+                        self.assertEqual(len(self.calls), 1)
+                        cmd, archive, path, _ = self.calls[0]
+                        self.assertEqual(path, f'/luma/titles/{title:016X}/exefs/{name}\0'.encode())
+                        self.assertEqual(archive, b'\0')
+                        self.assertEqual(cmd[:9], [0x08030204, 0, 9, 1, 1, 3, len(path), 1, 0])
+                        self.assertEqual(cmd[9], 0x4802)
+                        self.assertEqual(cmd[11], (len(path) << 14) | 2)
+                        self.assertEqual(self.uc.reg_read(UC_ARM_REG_R0), 0)
+
+    def test_fallback(self):
+        for transport, result in [(0, 0xC8804478), (0xD9001830, 0), (0, 0xD900458B)]:
+            with self.subTest(transport=transport, result=result):
+                self.calls.clear()
+                original = self.prepare('banner')
+                self.responses = [(transport, result), (0xD9009999, 0xD9008888)]
+                self.run_payload()
+                self.assertEqual(len(self.calls), 2)
+                self.assertEqual(self.calls[1][:3], original)
+                self.assertEqual(self.uc.reg_read(UC_ARM_REG_R0), 0xD9009999)
+
+    def test_unrelated_requests(self):
+        changes = [(0, 0x80201C2), (1, 1), (2, 3), (3, 3), (4, 12), (5, 3),
+                   (6, 12), (7, 3), (8, 1), (9, 0), (11, 0)]
+        for word, value in changes:
+            with self.subTest(word=word):
+                self.calls.clear()
+                cmd, archive, file = self.prepare()
+                cmd[word] = value
+                self.uc.mem_write(TLS + 0x80, pack(cmd))
+                self.run_payload()
+                self.assertEqual(len(self.calls), 1)
+                self.assertEqual(self.calls[0][0], cmd)
+        for name in ['logo', '.code', 'iconx', 'bannerx']:
+            with self.subTest(name=name):
+                self.calls.clear()
+                original = self.prepare(name)
+                self.run_payload()
+                self.assertEqual(len(self.calls), 1)
+                self.assertEqual(self.calls[0][:3], original)
+        for ptr, word, value in [(ARCHIVE, 1, 0x00040030), (ARCHIVE, 1, 0x0004000E),
+                                  (ARCHIVE, 2, 3), (ARCHIVE, 3, 1),
+                                  (FILE, 0, 1), (FILE, 1, 1), (FILE, 2, 0)]:
+            with self.subTest(ptr=ptr, word=word, value=value):
+                self.calls.clear()
+                cmd, _, _ = self.prepare()
+                self.uc.mem_write(ptr + word * 4, pack([value]))
+                self.run_payload()
+                self.assertEqual(len(self.calls), 1)
+                self.assertEqual(self.calls[0][0], cmd)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)


### PR DESCRIPTION
HOME Menu reads a title's ExeFS metadata before that title is launched, so the existing per-title RomFS hooks cannot replace its banner or icon. This draft adds a loader-installed hook for HOME Menu's `OpenFileDirectly` requests, resolving eligible reads to:

```text
/luma/titles/<TitleID>/exefs/banner
/luma/titles/<TitleID>/exefs/icon
```

Related to #1868. This is intentionally a draft: **no real HOME Menu binary or console has been tested yet**, so neither hook discovery on retail HOME Menu nor the visible result is established.

### Design

- Uses the existing game-patching gate and six HOME Menu TitleIDs. No kernel or Process9 changes, additional service, or FS session management.
- Finds an ARM literal load of the `OpenFileDirectly` IPC header and a unique call to its `svc 0x32; bx lr` stub. Only that call is redirected. Missing or ambiguous matches leave the executable unchanged.
- Places a 676-byte position-independent payload in unused text-page padding, reserving space for the existing RomFS payload. Occupied or insufficient padding skips the hook without preventing HOME Menu startup.
- Allows only read-only, main-content `icon`/`banner` requests for CTR applications and demos through the title-content archive. The path uses the title being opened, not HOME Menu's TitleID.
- On an unsuccessful replacement open or IPC transport failure, restores all 13 words of the original request and sends it normally. A successful open returns the replacement file handle; later file validation/read failures are not intercepted.
- Uses 160 bytes of per-invocation stack and no shared mutable payload state.

### Scope and limitations

SD-mode Luma only. This does not implement general ExeFS LayeredFS, other processes' reads, archive-handle-based `OpenFile`, update content, CTRNAND replacements, or `logo`. Existing icon caches are not invalidated, and extdata banners can take precedence. Unrecognized HOME Menu layouts silently retain their original behavior, so booting successfully is not proof that the hook was installed.

### Validation

- Built the complete `boot.firm` against upstream `aef31308a7ea33601d9d21cdede1dfd8471c07b0` with devkitARM r68 / GCC 16.1.0 and libctru 2.7.0, makerom, and firmtool.
- GCC `-fanalyzer -Wall -Wextra -Werror` passes for the new C installer.
- Eight automated test methods pass using Unicorn 2.1.4 and pyelftools 0.32. They execute the compiled ARM installer and a relocated payload, covering path construction, request filtering, failure fallback, register/stack restoration, ambiguous/missing call patterns, backwards calls, repeat installation, and occupied/reserved padding.
- FS responses and HOME Menu instruction fixtures are synthetic. These are not console or full-system emulator tests.
- `git diff --check` passes.

The usage notes and required hardware test matrix are in `docs/exefs-overrides.md`. Before marking this ready, we still need to verify hook discovery and rendering/cache behavior on actual HOME Menu versions, followed by Old/New 3DS, region, media, and existing game-patch regression tests. Maintainer feedback on the interception point and fallback policy is welcome.
